### PR TITLE
Adding the support for comma seperated audience/alias lists

### DIFF
--- a/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandler.java
+++ b/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandler.java
@@ -41,6 +41,7 @@ import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -195,7 +196,8 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
     protected boolean validateAudience(List<String> audiences, IdentityProvider idp, String requestedAudience,
                                        RequestParameter[] params) {
 
-        return audiences != null && audiences.stream().anyMatch(aud -> aud.equals(idp.getAlias()));
+        List<String> aliasList = Arrays.asList(idp.getAlias().trim().split("\\s*,\\s*"));
+        return audiences != null && aliasList.stream().anyMatch(new HashSet<>(audiences)::contains);
     }
 
     /**


### PR DESCRIPTION
## Purpose
Currently, there is no support for multiple alias values from an Identity Provider (IdP).

## Goals
Since some JWTs from the IdPs have multiple audience values those should be validated with a list of aliases as well.

## Approach
With this fix, if a person adds multiple comma-separated Alias values (example: "https://localhost:9443 , https://localhost:9444"), when validating the Audience, we will check whether at least one of the Alias values is matching with at least with one of the Audience values.