### PR TITLE
Support account lookup based on multiple attributes

### DIFF
--- a/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/pom.xml
+++ b/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/pom.xml
@@ -63,6 +63,10 @@
             <artifactId>org.wso2.carbon.identity.event</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.claim.metadata.mgt</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.wso2.carbon</groupId>
             <artifactId>org.wso2.carbon.user.core</artifactId>
         </dependency>
@@ -168,6 +172,8 @@
                             com.nimbusds.jose.*; version="${nimbusds.osgi.version.range}",
                             com.nimbusds.jwt; version="${nimbusds.osgi.version.range}",
                             org.wso2.carbon.identity.application.common.*;
+                            version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.claim.metadata.mgt.*;
                             version="${carbon.identity.package.import.version.range}",
                             org.apache.commons.lang; version="${commons-lang.wso2.osgi.version.range}",
                             org.apache.commons.logging; version="${commons-logging.osgi.version.range}",

--- a/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/Constants.java
+++ b/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/Constants.java
@@ -62,7 +62,7 @@ public class Constants {
         public static final String SUPPORTED_GRANT_TYPES = "SupportedGrantTypes";
     }
 
-    public enum SendLocalUser {
+    public enum UserLinkStrategy {
         DISABLED,
         OPTIONAL,
         MANDATORY

--- a/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/Constants.java
+++ b/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/Constants.java
@@ -34,7 +34,7 @@ public class Constants {
     static final String EXPIRY_TIME = "EXPIRY_TIME_JWT";
     public static final String DEFAULT_IDP_NAME = "default";
     public static final String OIDC_IDP_ENTITY_ID = "IdPEntityId";
-
+    public static final String OIDC_DIALECT_URI = "http://wso2.org/oidc/claim";
     public static final String LOCAL_IDP_NAME = "LOCAL";
     public static final String ERROR_GET_RESIDENT_IDP =
             "Error while getting Resident Identity Provider of '%s' tenant.";
@@ -60,5 +60,11 @@ public class Constants {
         public static final String GRANT_TYPE_NAME = "GrantTypeName";
         public static final String IAT_VALIDITY_PERIOD_IN_MIN = "IATValidityPeriod";
         public static final String SUPPORTED_GRANT_TYPES = "SupportedGrantTypes";
+    }
+
+    public enum SendLocalUser {
+        DISABLED,
+        OPTIONAL,
+        MANDATORY
     }
 }

--- a/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/internal/TokenExchangeComponentServiceHolder.java
+++ b/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/internal/TokenExchangeComponentServiceHolder.java
@@ -32,7 +32,6 @@ public class TokenExchangeComponentServiceHolder {
     private ApplicationManagementService applicationManagementService;
     private Map<Integer, UserOperationEventListener> userOperationEventListeners;
     private FederatedAssociationManager federatedAssociationManager;
-
     private ClaimMetadataManagementService claimMetadataManagementService;
 
     public static TokenExchangeComponentServiceHolder getInstance() {
@@ -99,6 +98,5 @@ public class TokenExchangeComponentServiceHolder {
 
         this.claimMetadataManagementService = claimMetadataManagementService;
     }
-
 
 }

--- a/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/internal/TokenExchangeComponentServiceHolder.java
+++ b/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/internal/TokenExchangeComponentServiceHolder.java
@@ -18,6 +18,7 @@
 package org.wso2.carbon.identity.oauth2.grant.token.exchange.internal;
 
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
+import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
 import org.wso2.carbon.identity.user.profile.mgt.association.federation.FederatedAssociationManager;
 import org.wso2.carbon.user.core.listener.UserOperationEventListener;
 import org.wso2.carbon.user.core.service.RealmService;
@@ -31,6 +32,8 @@ public class TokenExchangeComponentServiceHolder {
     private ApplicationManagementService applicationManagementService;
     private Map<Integer, UserOperationEventListener> userOperationEventListeners;
     private FederatedAssociationManager federatedAssociationManager;
+
+    private ClaimMetadataManagementService claimMetadataManagementService;
 
     public static TokenExchangeComponentServiceHolder getInstance() {
         return INSTANCE;
@@ -85,6 +88,16 @@ public class TokenExchangeComponentServiceHolder {
     public void setFederatedAssociationManager(FederatedAssociationManager federatedAssociationManager) {
 
         this.federatedAssociationManager = federatedAssociationManager;
+    }
+
+    public ClaimMetadataManagementService getClaimMetadataManagementService() {
+
+        return claimMetadataManagementService;
+    }
+
+    public void setClaimMetadataManagementService(ClaimMetadataManagementService claimMetadataManagementService) {
+
+        this.claimMetadataManagementService = claimMetadataManagementService;
     }
 
 

--- a/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/internal/TokenExchangeComponentServiceHolder.java
+++ b/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/internal/TokenExchangeComponentServiceHolder.java
@@ -22,7 +22,6 @@ import org.wso2.carbon.identity.user.profile.mgt.association.federation.Federate
 import org.wso2.carbon.user.core.listener.UserOperationEventListener;
 import org.wso2.carbon.user.core.service.RealmService;
 
-import java.util.Collection;
 import java.util.Map;
 
 public class TokenExchangeComponentServiceHolder {
@@ -30,7 +29,6 @@ public class TokenExchangeComponentServiceHolder {
     private static final TokenExchangeComponentServiceHolder INSTANCE = new TokenExchangeComponentServiceHolder();
     private RealmService realmService;
     private ApplicationManagementService applicationManagementService;
-    private Collection<UserOperationEventListener> userOperationEventListenerCollection;
     private Map<Integer, UserOperationEventListener> userOperationEventListeners;
     private FederatedAssociationManager federatedAssociationManager;
 
@@ -56,17 +54,6 @@ public class TokenExchangeComponentServiceHolder {
     public void setApplicationManagementService(ApplicationManagementService applicationManagementService) {
 
         this.applicationManagementService = applicationManagementService;
-    }
-
-    public Collection<UserOperationEventListener> getUserOperationEventListenerCollection() {
-
-        return userOperationEventListenerCollection;
-    }
-
-    public void setUserOperationEventListenerCollection(Collection<UserOperationEventListener>
-                                                                userOperationEventListenerCollection) {
-
-        this.userOperationEventListenerCollection = userOperationEventListenerCollection;
     }
 
     public Map<Integer, UserOperationEventListener> getUserOperationEventListeners() {

--- a/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/internal/TokenExchangeServiceComponent.java
+++ b/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/internal/TokenExchangeServiceComponent.java
@@ -26,6 +26,7 @@ import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
+import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
 import org.wso2.carbon.identity.user.profile.mgt.association.federation.FederatedAssociationManager;
 import org.wso2.carbon.user.core.listener.UserOperationEventListener;
 import org.wso2.carbon.user.core.service.RealmService;
@@ -146,6 +147,22 @@ public class TokenExchangeServiceComponent {
                     "bundle");
         }
         TokenExchangeComponentServiceHolder.getInstance().setFederatedAssociationManager(null);
+    }
+
+    @Reference(
+            name = "claimManagementService",
+            service = ClaimMetadataManagementService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetClaimMetadataManagementService")
+    protected void setClaimMetadataManagementService(ClaimMetadataManagementService claimManagementService) {
+
+        TokenExchangeComponentServiceHolder.getInstance().setClaimMetadataManagementService(claimManagementService);
+    }
+
+    protected void unsetClaimMetadataManagementService(ClaimMetadataManagementService claimManagementService) {
+
+        TokenExchangeComponentServiceHolder.getInstance().setClaimMetadataManagementService(null);
     }
 
     public static Collection<UserOperationEventListener> getUserOperationEventListeners() {

--- a/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/internal/TokenExchangeServiceComponent.java
+++ b/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/internal/TokenExchangeServiceComponent.java
@@ -106,7 +106,6 @@ public class TokenExchangeServiceComponent {
             policy = ReferencePolicy.DYNAMIC,
             unbind = "unsetUserOperationEventListenerService")
     protected void setUserOperationEventListenerService(UserOperationEventListener userOperationEventListenerService) {
-        TokenExchangeComponentServiceHolder.getInstance().setUserOperationEventListenerCollection(null);
         if (TokenExchangeComponentServiceHolder.getInstance().getUserOperationEventListeners() == null) {
             TokenExchangeComponentServiceHolder.getInstance().setUserOperationEventListeners(
                     new TreeMap<Integer, UserOperationEventListener>());
@@ -122,7 +121,6 @@ public class TokenExchangeServiceComponent {
                 TokenExchangeComponentServiceHolder.getInstance().getUserOperationEventListeners() != null) {
             TokenExchangeComponentServiceHolder.getInstance().removeUserOperationEventListener(
                     userOperationEventListenerService.getExecutionOrderId());
-            TokenExchangeComponentServiceHolder.getInstance().setUserOperationEventListenerCollection(null);
         }
     }
 
@@ -153,20 +151,13 @@ public class TokenExchangeServiceComponent {
     public static Collection<UserOperationEventListener> getUserOperationEventListeners() {
         Map<Integer, UserOperationEventListener> userOperationEventListeners =
                 TokenExchangeComponentServiceHolder.getInstance().getUserOperationEventListeners();
-        Collection<UserOperationEventListener> userOperationEventListenerCollection =
-                TokenExchangeComponentServiceHolder.getInstance().getUserOperationEventListenerCollection();
+
         if (userOperationEventListeners == null) {
             userOperationEventListeners = new TreeMap<>();
             TokenExchangeComponentServiceHolder.getInstance().setUserOperationEventListeners(
                     userOperationEventListeners);
         }
 
-        if (userOperationEventListenerCollection == null) {
-            userOperationEventListenerCollection = userOperationEventListeners.values();
-            TokenExchangeComponentServiceHolder.getInstance().setUserOperationEventListenerCollection(
-                    userOperationEventListenerCollection);
-        }
-
-        return userOperationEventListenerCollection;
+        return userOperationEventListeners.values();
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -209,7 +209,7 @@
         <carbon.p2.plugin.version>1.5.3</carbon.p2.plugin.version>
         <carbon.identity.oauth.package.import.version.range>[6.0.0, 7.0.0)</carbon.identity.oauth.package.import.version.range>
         <carbon.identity.oauth.version>6.4.111</carbon.identity.oauth.version>
-        <carbon.identity.framework.version>5.25.407</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.481</carbon.identity.framework.version>
         <commons-lang.wso2.osgi.version.range>[2.6.0,3.0.0)</commons-lang.wso2.osgi.version.range>
         <commons-logging.osgi.version.range>[1.2,2.0)</commons-logging.osgi.version.range>
         <equinox.osgi.services.version>3.5.100.v20160504-1419</equinox.osgi.services.version>

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,11 @@
                 <version>${carbon.identity.framework.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
+                <artifactId>org.wso2.carbon.identity.claim.metadata.mgt</artifactId>
+                <version>${carbon.identity.framework.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.wso2.orbit.commons-collections</groupId>
                 <artifactId>commons-collections</artifactId>
                 <version>${commons-collections.version}</version>


### PR DESCRIPTION
Initially account lookup was possible only using the `email` attribute. This PR adds the capability to perform matching user account lookup based on any attribute in the OIDC claim dialect or based on custom idp claim mappings

Also the improved assert local subject identifier service provider configuration is utilized to check wether or not to issue token for a local user account
