### PR TITLE
Improve account lock error message

### DIFF
--- a/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/pom.xml
+++ b/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/pom.xml
@@ -116,6 +116,10 @@
             <artifactId>org.wso2.carbon.identity.core</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.event.handler.accountlock</groupId>
+            <artifactId>org.wso2.carbon.identity.handler.event.account.lock</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.ws.commons.axiom.wso2</groupId>
             <artifactId>axiom</artifactId>
         </dependency>
@@ -160,6 +164,8 @@
                             org.wso2.carbon.user.core.*; version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.identity.application.authentication.framework.*;
                             version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.handler.event.account.lock.exception;
+                            version="${carbon.identity.account.lock.handler.imp.pkg.version.range}",
                             org.wso2.carbon.identity.application.mgt;
                             version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.event;

--- a/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/pom.xml
+++ b/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/pom.xml
@@ -75,6 +75,10 @@
             <artifactId>org.wso2.carbon.core</artifactId>
         </dependency>
         <dependency>
+            <artifactId>org.wso2.carbon.identity.central.log.mgt</artifactId>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+        </dependency>
+        <dependency>
             <groupId>org.json.wso2</groupId>
             <artifactId>json</artifactId>
         </dependency>
@@ -175,6 +179,8 @@
                             org.wso2.carbon.utils.*; version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.identity.recovery.*;
                             version="${identity.governance.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.central.log.mgt.utils;
+                            version="${carbon.identity.package.import.version.range}",
                             com.nimbusds.jose.*; version="${nimbusds.osgi.version.range}",
                             com.nimbusds.jwt; version="${nimbusds.osgi.version.range}",
                             org.wso2.carbon.identity.application.common.*;

--- a/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/pom.xml
+++ b/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/pom.xml
@@ -191,7 +191,7 @@
                             version="${carbon.identity.package.import.version.range}",
                             org.apache.commons.lang; version="${commons-lang.wso2.osgi.version.range}",
                             org.apache.commons.logging; version="${commons-logging.osgi.version.range}",
-                            org.wso2.carbon.idp.mgt.*; version="${carbon.identity.framework.version}",
+                            org.wso2.carbon.idp.mgt.*; version="${carbon.identity.package.import.version.range}",
                             net.minidev.json; version="${net.minidev.json.imp.pkg.version.range}",
                             org.apache.commons.collections; version="${commons-collections.wso2.osgi.version.range}",
                             org.apache.axiom.om; version="${axiom.osgi.version.range}"

--- a/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/pom.xml
+++ b/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/pom.xml
@@ -155,6 +155,8 @@
                             javax.servlet.http; version="${imp.pkg.version.javax.servlet}",
                             org.apache.oltu.oauth2.common.validators; version="${oltu.package.import.version.range}",
                             org.apache.oltu.oauth2.common; version="${oltu.package.import.version.range}",
+                            org.json;version="${wso2.json.version.range}",
+                            org.wso2.carbon; version="${carbon.kernel.package.import.version.range}",
                             !org.wso2.carbon.identity.oauth2.grant.token.exchange.*,
                             org.wso2.carbon.identity.oauth2.*;
                             version="${carbon.identity.oauth.package.import.version.range}",

--- a/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/Constants.java
+++ b/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/Constants.java
@@ -72,6 +72,17 @@ public class Constants {
         }
     }
 
+    public static class AuditConstants {
+        public static final String AUDIT_MESSAGE =
+                "Initiator : %s | Action : %s | Target : %s | Data : %s | Result : %s ";
+        public static final String IMPLICIT_ACCOUNT_LINK = "Implicit-Account-Link";
+        public static final String AUDIT_SUCCESS = "Success";
+        public static final String IDP_ID = "identityProviderId";
+        public static final String IDP_NAME = "identityProviderName";
+        public static final String APPLICATION_ID = "applicationId";
+
+    }
+
     public enum UserLinkStrategy {
         DISABLED,
         OPTIONAL,

--- a/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/Constants.java
+++ b/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/Constants.java
@@ -62,6 +62,16 @@ public class Constants {
         public static final String SUPPORTED_GRANT_TYPES = "SupportedGrantTypes";
     }
 
+    public static class LogConstants {
+        public static final String COMPONENT_ID = "oauth2-grant-token-exchange";
+
+        public static class ActionIDs {
+            public static final String AUTHORIZE_LINKED_LOCAL_USER = "authorize-linked-local-user";
+            public static final String GET_LOCAL_USER = "get-local-user";
+            public static final String CREATE_IMPLICIT_ACCOUNT_LINK = "create-implicit-account-link";
+        }
+    }
+
     public enum UserLinkStrategy {
         DISABLED,
         OPTIONAL,

--- a/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/Constants.java
+++ b/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/Constants.java
@@ -63,9 +63,11 @@ public class Constants {
     }
 
     public static class LogConstants {
+
         public static final String COMPONENT_ID = "oauth2-grant-token-exchange";
 
         public static class ActionIDs {
+
             public static final String AUTHORIZE_LINKED_LOCAL_USER = "authorize-linked-local-user";
             public static final String GET_LOCAL_USER = "get-local-user";
             public static final String CREATE_IMPLICIT_ACCOUNT_LINK = "create-implicit-account-link";
@@ -73,6 +75,7 @@ public class Constants {
     }
 
     public static class AuditConstants {
+
         public static final String AUDIT_MESSAGE =
                 "Initiator : %s | Action : %s | Target : %s | Data : %s | Result : %s ";
         public static final String IMPLICIT_ACCOUNT_LINK = "Implicit-Account-Link";
@@ -84,6 +87,7 @@ public class Constants {
     }
 
     public enum UserLinkStrategy {
+
         DISABLED,
         OPTIONAL,
         MANDATORY

--- a/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandler.java
+++ b/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandler.java
@@ -148,7 +148,7 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
 
                 if (e.getCause() instanceof IdentityEventException) {
                     handleException(OAuth2ErrorCodes.ACCESS_DENIED, "Local user authorization failed: " +
-                            e.getLocalizedMessage());
+                            e.getCause().getLocalizedMessage());
                 }
 
                 handleException(OAuth2ErrorCodes.SERVER_ERROR, e);

--- a/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandler.java
+++ b/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandler.java
@@ -191,6 +191,20 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
                     handleException(OAuth2ErrorCodes.ACCESS_DENIED, errorMessage);
                 }
 
+                if (LoggerUtils.isDiagnosticLogsEnabled()) {
+                    DiagnosticLog.DiagnosticLogBuilder diagnosticLogBuilder =
+                            new DiagnosticLog.DiagnosticLogBuilder(
+                                    Constants.LogConstants.COMPONENT_ID,
+                                    Constants.LogConstants.ActionIDs.AUTHORIZE_LINKED_LOCAL_USER
+                            );
+                    diagnosticLogBuilder
+                            .resultMessage("Server error while validating linked local user: " +
+                                    e.getLocalizedMessage())
+                            .logDetailLevel(DiagnosticLog.LogDetailLevel.APPLICATION)
+                            .resultStatus(DiagnosticLog.ResultStatus.FAILED);
+                    LoggerUtils.triggerDiagnosticLogEvent(diagnosticLogBuilder);
+                }
+
                 handleException(OAuth2ErrorCodes.SERVER_ERROR, e);
             }
         }

--- a/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandler.java
+++ b/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandler.java
@@ -174,7 +174,6 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
                 if (e.getCause() instanceof IdentityEventException) {
                     String errorMessage = "Local user authorization failed for user: " + userId +
                             " cause: " + e.getCause().getLocalizedMessage();
-                    handleException(OAuth2ErrorCodes.ACCESS_DENIED, errorMessage);
 
                     if (LoggerUtils.isDiagnosticLogsEnabled()) {
                         DiagnosticLog.DiagnosticLogBuilder diagnosticLogBuilder =
@@ -188,6 +187,8 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
                                 .resultStatus(DiagnosticLog.ResultStatus.FAILED);
                         LoggerUtils.triggerDiagnosticLogEvent(diagnosticLogBuilder);
                     }
+
+                    handleException(OAuth2ErrorCodes.ACCESS_DENIED, errorMessage);
                 }
 
                 handleException(OAuth2ErrorCodes.SERVER_ERROR, e);

--- a/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandler.java
+++ b/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandler.java
@@ -29,6 +29,7 @@ import org.wso2.carbon.identity.application.authentication.framework.model.Authe
 import org.wso2.carbon.identity.application.common.model.ClaimMapping;
 import org.wso2.carbon.identity.application.common.model.IdentityProvider;
 import org.wso2.carbon.identity.event.IdentityEventException;
+import org.wso2.carbon.identity.handler.event.account.lock.exception.AccountLockException;
 import org.wso2.carbon.identity.oauth.common.OAuth2ErrorCodes;
 import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
@@ -140,10 +141,16 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
                 listener.doPostAuthenticate(tokReqMsgCtx.getAuthorizedUser().getUserName(), false,
                         userStoreManager);
             } catch (UserStoreException e) {
+                if (e.getCause() instanceof AccountLockException) {
+                    handleException(OAuth2ErrorCodes.ACCESS_DENIED, "Local user authorization failed: " +
+                            "linked local account is locked");
+                }
+
                 if (e.getCause() instanceof IdentityEventException) {
                     handleException(OAuth2ErrorCodes.ACCESS_DENIED, "Local user authorization failed: " +
-                            e.getCause().getLocalizedMessage());
+                            e.getLocalizedMessage());
                 }
+
                 handleException(OAuth2ErrorCodes.SERVER_ERROR, e);
             }
         }

--- a/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandler.java
+++ b/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandler.java
@@ -172,8 +172,22 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
                 }
 
                 if (e.getCause() instanceof IdentityEventException) {
-                    handleException(OAuth2ErrorCodes.ACCESS_DENIED, "Local user authorization failed: " +
-                            e.getCause().getLocalizedMessage());
+                    String errorMessage = "Local user authorization failed for user: " + userId +
+                            " cause: " + e.getCause().getLocalizedMessage();
+                    handleException(OAuth2ErrorCodes.ACCESS_DENIED, errorMessage);
+
+                    if (LoggerUtils.isDiagnosticLogsEnabled()) {
+                        DiagnosticLog.DiagnosticLogBuilder diagnosticLogBuilder =
+                                new DiagnosticLog.DiagnosticLogBuilder(
+                                        Constants.LogConstants.COMPONENT_ID,
+                                        Constants.LogConstants.ActionIDs.AUTHORIZE_LINKED_LOCAL_USER
+                                );
+                        diagnosticLogBuilder
+                                .resultMessage(errorMessage)
+                                .logDetailLevel(DiagnosticLog.LogDetailLevel.APPLICATION)
+                                .resultStatus(DiagnosticLog.ResultStatus.FAILED);
+                        LoggerUtils.triggerDiagnosticLogEvent(diagnosticLogBuilder);
+                    }
                 }
 
                 handleException(OAuth2ErrorCodes.SERVER_ERROR, e);

--- a/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandler.java
+++ b/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandler.java
@@ -25,9 +25,11 @@ import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.application.authentication.framework.exception.UserIdNotFoundException;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
 import org.wso2.carbon.identity.application.common.model.ClaimMapping;
 import org.wso2.carbon.identity.application.common.model.IdentityProvider;
+import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
 import org.wso2.carbon.identity.event.IdentityEventException;
 import org.wso2.carbon.identity.handler.event.account.lock.exception.AccountLockException;
 import org.wso2.carbon.identity.oauth.common.OAuth2ErrorCodes;
@@ -44,6 +46,7 @@ import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 import org.wso2.carbon.user.core.UserStoreException;
 import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
 import org.wso2.carbon.user.core.listener.UserOperationEventListener;
+import org.wso2.carbon.utils.DiagnosticLog;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
 import java.util.Arrays;
@@ -135,6 +138,13 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
     private void validateLocalUser(OAuthTokenReqMessageContext tokReqMsgCtx, Map<String, String> requestParams)
             throws IdentityOAuth2Exception {
 
+        String userId = null;
+        try {
+            userId = tokReqMsgCtx.getAuthorizedUser().getUserId();
+        } catch (UserIdNotFoundException e) {
+            handleException(OAuth2ErrorCodes.SERVER_ERROR, e);
+        }
+
         AbstractUserStoreManager userStoreManager = TokenExchangeUtils.getUserStoreManager(tokReqMsgCtx);
         for (UserOperationEventListener listener : TokenExchangeServiceComponent.getUserOperationEventListeners()) {
             try {
@@ -142,8 +152,23 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
                         userStoreManager);
             } catch (UserStoreException e) {
                 if (e.getCause() instanceof AccountLockException) {
-                    handleException(OAuth2ErrorCodes.ACCESS_DENIED, "Local user authorization failed: " +
-                            "linked local account is locked");
+                    String errorMessage = "Local user authorization failed: linked local account with id " + userId +
+                            " is locked";
+
+                    if (LoggerUtils.isDiagnosticLogsEnabled()) {
+                        DiagnosticLog.DiagnosticLogBuilder diagnosticLogBuilder =
+                                new DiagnosticLog.DiagnosticLogBuilder(
+                                        Constants.LogConstants.COMPONENT_ID,
+                                        Constants.LogConstants.ActionIDs.AUTHORIZE_LINKED_LOCAL_USER
+                                );
+                        diagnosticLogBuilder
+                                .resultMessage(errorMessage)
+                                .logDetailLevel(DiagnosticLog.LogDetailLevel.APPLICATION)
+                                .resultStatus(DiagnosticLog.ResultStatus.FAILED);
+                        LoggerUtils.triggerDiagnosticLogEvent(diagnosticLogBuilder);
+                    }
+
+                    handleException(OAuth2ErrorCodes.ACCESS_DENIED, errorMessage);
                 }
 
                 if (e.getCause() instanceof IdentityEventException) {

--- a/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/utils/TokenExchangeUtils.java
+++ b/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/utils/TokenExchangeUtils.java
@@ -714,7 +714,7 @@ public class TokenExchangeUtils {
                     + tenantDomain, e);
         }
         AuthenticatedUser user = tokReqMsgCtx.getAuthorizedUser();
-        if (MapUtils.isNotEmpty(mappedClaims)) {
+        if (MapUtils.isNotEmpty(mappedClaims) && user.isFederatedUser()) {
             user.setUserAttributes(FrameworkUtils.buildClaimMappings(mappedClaims));
         }
         tokReqMsgCtx.setAuthorizedUser(user);

--- a/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/utils/TokenExchangeUtils.java
+++ b/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/utils/TokenExchangeUtils.java
@@ -363,8 +363,8 @@ public class TokenExchangeUtils {
             UserLinkStrategy localUserLinking = resolveLocalUserLinkingStrategy(serviceProviderClaimConfig);
             Optional<User> localUser = Optional.empty();
             if (localUserLinking == UserLinkStrategy.OPTIONAL || localUserLinking == UserLinkStrategy.MANDATORY) {
-                // check if the federated user already has an associated local user.
-                // If so no need to perform claim based account lookup
+                // Check if the federated user already has an associated local user.
+                // If so no need to perform claim based account lookup.
                 localUser = getAlreadyAssociatedLocalUser(tokenReqMsgCtx, identityProvider,
                         authenticatedSubjectIdentifier);
             }
@@ -983,7 +983,7 @@ public class TokenExchangeUtils {
      * @return  Matching local user account
      * @throws IdentityOAuth2Exception  Error when resolving local user account
      */
-    public static User getLocalUser(OAuthTokenReqMessageContext tokReqMsgCtx,
+    private static User getLocalUser(OAuthTokenReqMessageContext tokReqMsgCtx,
                                     Map<String, String> claims) throws IdentityOAuth2Exception {
 
         String tenantDomain = tokReqMsgCtx.getOauth2AccessTokenReqDTO().getTenantDomain();
@@ -1122,6 +1122,7 @@ public class TokenExchangeUtils {
      * @return Assert local user behaviour.
      */
     private static UserLinkStrategy resolveLocalUserLinkingStrategy(ClaimConfig claimConfig) {
+
         if (claimConfig == null) {
             return UserLinkStrategy.DISABLED;
         }

--- a/pom.xml
+++ b/pom.xml
@@ -230,7 +230,7 @@
         <carbon.identity.package.import.version.range>[5.0.0, 7.0.0)</carbon.identity.package.import.version.range>
         <commons-collections.version>3.2.2.wso2v1</commons-collections.version>
         <commons-collections.wso2.osgi.version.range>[3.2.0,4.0.0)</commons-collections.wso2.osgi.version.range>
-        <carbon.kernel.package.import.version.range>[4.4.0, 5.0.0)</carbon.kernel.package.import.version.range>
+        <carbon.kernel.package.import.version.range>[4.9.0, 5.0.0)</carbon.kernel.package.import.version.range>
         <carbon.user.api.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.user.api.imp.pkg.version.range>
         <identity.governance.version>1.8.73</identity.governance.version>
         <identity.governance.imp.pkg.version.range>[1.5.89, 3.0.0)</identity.governance.imp.pkg.version.range>

--- a/pom.xml
+++ b/pom.xml
@@ -167,6 +167,11 @@
                 <version>${carbon.identity.framework.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.wso2.carbon.identity.event.handler.accountlock</groupId>
+                <artifactId>org.wso2.carbon.identity.handler.event.account.lock</artifactId>
+                <version>${carbon.identity.account.lock.handler.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.ws.commons.axiom.wso2</groupId>
                 <artifactId>axiom</artifactId>
                 <version>${axiom.wso2.version}</version>
@@ -225,6 +230,9 @@
         <identity.governance.version>1.8.73</identity.governance.version>
         <identity.governance.imp.pkg.version.range>[1.5.89, 3.0.0)</identity.governance.imp.pkg.version.range>
         <carbon.kernel.version>4.6.2</carbon.kernel.version>
+        <carbon.identity.account.lock.handler.version>1.8.13</carbon.identity.account.lock.handler.version>
+        <carbon.identity.account.lock.handler.imp.pkg.version.range>[1.8.13, 2.0.0)
+        </carbon.identity.account.lock.handler.imp.pkg.version.range>
         <commons-lang.wso2.version>2.6.0.wso2v1</commons-lang.wso2.version>
         <nimbusds.osgi.version.range>[7.3.0,8.0.0)</nimbusds.osgi.version.range>
         <net.minidev.json.imp.pkg.version.range>[2.3.0, 3.0.0)</net.minidev.json.imp.pkg.version.range>

--- a/pom.xml
+++ b/pom.xml
@@ -111,6 +111,11 @@
                 <version>${identity.governance.version}</version>
             </dependency>
             <dependency>
+                <artifactId>org.wso2.carbon.identity.central.log.mgt</artifactId>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
+                <version>${carbon.identity.framework.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.json.wso2</groupId>
                 <artifactId>json</artifactId>
                 <version>${wso2.json}</version>
@@ -229,7 +234,7 @@
         <carbon.user.api.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.user.api.imp.pkg.version.range>
         <identity.governance.version>1.8.73</identity.governance.version>
         <identity.governance.imp.pkg.version.range>[1.5.89, 3.0.0)</identity.governance.imp.pkg.version.range>
-        <carbon.kernel.version>4.6.2</carbon.kernel.version>
+        <carbon.kernel.version>4.9.19</carbon.kernel.version>
         <carbon.identity.account.lock.handler.version>1.8.13</carbon.identity.account.lock.handler.version>
         <carbon.identity.account.lock.handler.imp.pkg.version.range>[1.8.13, 2.0.0)
         </carbon.identity.account.lock.handler.imp.pkg.version.range>

--- a/pom.xml
+++ b/pom.xml
@@ -242,6 +242,7 @@
         <nimbusds.osgi.version.range>[7.3.0,8.0.0)</nimbusds.osgi.version.range>
         <net.minidev.json.imp.pkg.version.range>[2.3.0, 3.0.0)</net.minidev.json.imp.pkg.version.range>
         <wso2.json>3.0.0.wso2v1</wso2.json>
+        <wso2.json.version.range>[3.0.0.wso2v1, 4.0.0)</wso2.json.version.range>
         <nimbusds.version>7.3.0.wso2v1</nimbusds.version>
         <axiom.version>1.2.11-wso2v6</axiom.version>
         <javax.servlet-api.version>3.0-alpha-1</javax.servlet-api.version>


### PR DESCRIPTION
This PR adds the following changes

- Update the error message for account lock error response to ensure no PIIs are logged
- Fixed a bug where the token contained user attributes of the subject token even when the exchanged token is issued for a local user
- Adds diagnostics logs 
- Use a version range when importing org.wso2.carbon.idp.mgt