### PR TITLE
Handle Invalid Subject Token Client Error Properly

### DIFF
--- a/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/Constants.java
+++ b/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/Constants.java
@@ -38,6 +38,8 @@ public class Constants {
     public static final String LOCAL_IDP_NAME = "LOCAL";
     public static final String ERROR_GET_RESIDENT_IDP =
             "Error while getting Resident Identity Provider of '%s' tenant.";
+    public static final String SUBJECT_TOKEN_IS_NOT_ACTIVE_ERROR_MESSAGE =
+            "Invalid Subject Token. Subject token is not ACTIVE.";
 
     public static final String OAUTH_APP_DO_PROPERTY = "OAuthAppDO";
 


### PR DESCRIPTION
### Purpose
- When an invalid/ revoked token (issued by resident trusted token issuer) is sent as the subject token in the token exchange grant request, it returns a `500 -Internal Server Error`. Since this should be a client error, with this PR the said error is handled properly by sending a `400 - Bad Request` in response.  

