### PR TITLE
[Impersonation] Improve email date format

### DIFF
--- a/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/impersonation/notifiers/ImpersonationEmailNotifier.java
+++ b/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/impersonation/notifiers/ImpersonationEmailNotifier.java
@@ -51,7 +51,7 @@ public class ImpersonationEmailNotifier {
 
     private static final Log LOG = LogFactory.getLog(ImpersonationEmailNotifier.class);
     private static final String UTC = "UTC";
-    private static final String DATE_FORMAT = "MMMM dd, yyyy 'at' hh:mm a";
+    private static final String DATE_FORMAT = "MMMM dd, yyyy 'at' hh:mm a z";
     private static final String USER_NAME = "user-name";
     private static final String LOGIN_TIME = "login-time";
     private static final String IMPERSONATION_USER_NAME = "impersonator-user-name";


### PR DESCRIPTION
Current email date format is
```
July 17, 2024 at 08:37 AM
```

But its missing Zone which may confuse users. Hence adding zone
```
July 17, 2024 at 08:37 AM UTC 
```