### PR TITLE
Fix account getting locked in token exchange flow

### DIFF
--- a/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandler.java
+++ b/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandler.java
@@ -408,8 +408,7 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
 
         for (UserOperationEventListener listener : TokenExchangeServiceComponent.getUserOperationEventListeners()) {
             try {
-                IdentityUtil.threadLocalProperties.get().put(IdentityCoreConstants.GRANT_TYPE,
-                        TokenExchangeConstants.TOKEN_EXCHANGE_GRANT_TYPE);
+                IdentityUtil.threadLocalProperties.get().put(IdentityCoreConstants.SKIP_LOCAL_USER_CLAIM_UPDATE, true);
                 listener.doPostAuthenticate(userName, false, userStoreManager);
             } catch (UserStoreException e) {
                 if (e.getCause() instanceof AccountLockException) {
@@ -447,7 +446,7 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
 
                 handleException(OAuth2ErrorCodes.SERVER_ERROR, e);
             } finally {
-                IdentityUtil.threadLocalProperties.get().remove(IdentityCoreConstants.GRANT_TYPE);
+                IdentityUtil.threadLocalProperties.get().remove(IdentityCoreConstants.SKIP_LOCAL_USER_CLAIM_UPDATE);
             }
         }
     }

--- a/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandler.java
+++ b/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandler.java
@@ -408,8 +408,8 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
 
         for (UserOperationEventListener listener : TokenExchangeServiceComponent.getUserOperationEventListeners()) {
             try {
-                IdentityUtil.threadLocalProperties.set(Collections.singletonMap(
-                        IdentityCoreConstants.GRANT_TYPE, TokenExchangeConstants.TOKEN_EXCHANGE_GRANT_TYPE));
+                IdentityUtil.threadLocalProperties.get().put(IdentityCoreConstants.GRANT_TYPE,
+                        TokenExchangeConstants.TOKEN_EXCHANGE_GRANT_TYPE);
                 listener.doPostAuthenticate(userName, false, userStoreManager);
             } catch (UserStoreException e) {
                 if (e.getCause() instanceof AccountLockException) {

--- a/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandler.java
+++ b/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandler.java
@@ -31,6 +31,7 @@ import org.wso2.carbon.identity.application.authentication.framework.model.Authe
 import org.wso2.carbon.identity.application.common.model.ClaimMapping;
 import org.wso2.carbon.identity.application.common.model.IdentityProvider;
 import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.event.IdentityEventException;
 import org.wso2.carbon.identity.handler.event.account.lock.exception.AccountLockException;
 import org.wso2.carbon.identity.oauth.common.OAuth2ErrorCodes;
@@ -397,6 +398,10 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
         AbstractUserStoreManager userStoreManager = TokenExchangeUtils.getUserStoreManager(tokReqMsgCtx);
         for (UserOperationEventListener listener : TokenExchangeServiceComponent.getUserOperationEventListeners()) {
             try {
+                Map<String, Object> threadLocalProps = new HashMap<>();
+                // TODO: Move GrantType to IdentityCoreConstants.
+                threadLocalProps.put("GrantType", TokenExchangeConstants.TOKEN_EXCHANGE_GRANT_TYPE);
+                IdentityUtil.threadLocalProperties.set(threadLocalProps);
                 listener.doPostAuthenticate(tokReqMsgCtx.getAuthorizedUser().getUserName(), false,
                         userStoreManager);
             } catch (UserStoreException e) {
@@ -434,6 +439,8 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
                 }
 
                 handleException(OAuth2ErrorCodes.SERVER_ERROR, e);
+            } finally {
+                IdentityUtil.threadLocalProperties.get().remove("GrantType");
             }
         }
     }

--- a/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandler.java
+++ b/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandler.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2021-2025, WSO2 LLC. (http://www.wso2.com).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -13,7 +13,7 @@
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
- * under the License
+ * under the License.
  */
 
 package org.wso2.carbon.identity.oauth2.grant.token.exchange;

--- a/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandler.java
+++ b/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandler.java
@@ -31,6 +31,7 @@ import org.wso2.carbon.identity.application.authentication.framework.model.Authe
 import org.wso2.carbon.identity.application.common.model.ClaimMapping;
 import org.wso2.carbon.identity.application.common.model.IdentityProvider;
 import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
+import org.wso2.carbon.identity.core.util.IdentityCoreConstants;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.event.IdentityEventException;
 import org.wso2.carbon.identity.handler.event.account.lock.exception.AccountLockException;
@@ -54,6 +55,7 @@ import org.wso2.carbon.utils.DiagnosticLog;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -406,10 +408,8 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
 
         for (UserOperationEventListener listener : TokenExchangeServiceComponent.getUserOperationEventListeners()) {
             try {
-                Map<String, Object> threadLocalProps = new HashMap<>();
-                // TODO: Move GrantType to IdentityCoreConstants.
-                threadLocalProps.put("GrantType", TokenExchangeConstants.TOKEN_EXCHANGE_GRANT_TYPE);
-                IdentityUtil.threadLocalProperties.set(threadLocalProps);
+                IdentityUtil.threadLocalProperties.set(Collections.singletonMap(
+                        IdentityCoreConstants.GRANT_TYPE, TokenExchangeConstants.TOKEN_EXCHANGE_GRANT_TYPE));
                 listener.doPostAuthenticate(userName, false, userStoreManager);
             } catch (UserStoreException e) {
                 if (e.getCause() instanceof AccountLockException) {
@@ -447,7 +447,7 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
 
                 handleException(OAuth2ErrorCodes.SERVER_ERROR, e);
             } finally {
-                IdentityUtil.threadLocalProperties.get().remove("GrantType");
+                IdentityUtil.threadLocalProperties.get().remove(IdentityCoreConstants.GRANT_TYPE);
             }
         }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -230,7 +230,7 @@
         <carbon.p2.plugin.version>1.5.3</carbon.p2.plugin.version>
         <carbon.identity.oauth.package.import.version.range>[6.0.0, 8.0.0)</carbon.identity.oauth.package.import.version.range>
         <carbon.identity.oauth.version>7.0.286</carbon.identity.oauth.version>
-        <carbon.identity.framework.version>7.8.111</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.8.146</carbon.identity.framework.version>
         <commons-lang.wso2.osgi.version.range>[2.6.0,3.0.0)</commons-lang.wso2.osgi.version.range>
         <commons-logging.osgi.version.range>[1.2,2.0)</commons-logging.osgi.version.range>
         <equinox.osgi.services.version>3.5.100.v20160504-1419</equinox.osgi.services.version>


### PR DESCRIPTION
- Add GrantType to IdentityUtil.threadLocalProperties in the TokenExchangeGrantHandler, allowing AccountLockHandler to detect token exchange and bypass unnecessary account lock claims update.

- Fix username resolving logic.

### Related PRs
- https://github.com/wso2-extensions/identity-event-handler-account-lock/pull/147