### PR TITLE
Apply configurable PRIMARY user store search during Token Exchange implicit association when secondary user stores are present

### DIFF
--- a/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/Constants.java
+++ b/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/Constants.java
@@ -43,6 +43,9 @@ public class Constants {
 
     public static final String OAUTH_APP_DO_PROPERTY = "OAuthAppDO";
 
+    public static final String INCLUDE_PRIMARY_WHEN_SECONDARY_PRESENT_IN_TOKEN_EXCHANGE_IMPLICIT_ASSOCIATION =
+            "TokenExchange.ImplicitAssociation.IncludePrimaryWhenSecondaryPresent";
+
     public static class TokenExchangeConstants {
 
         public static final String TOKEN_EXCHANGE_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:token-exchange";

--- a/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/utils/TokenExchangeUtils.java
+++ b/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/utils/TokenExchangeUtils.java
@@ -1180,6 +1180,7 @@ public class TokenExchangeUtils {
 
         RealmService realmService = TokenExchangeComponentServiceHolder.getInstance().getRealmService();
         String tenantDomain = tokReqMsgCtx.getOauth2AccessTokenReqDTO().getTenantDomain();
+        AbstractUserStoreManager userStoreManager = null;
 
         if (StringUtils.isEmpty(tenantDomain)) {
             tenantDomain = MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
@@ -1188,11 +1189,16 @@ public class TokenExchangeUtils {
 
         try {
             UserRealm realm = (UserRealm) realmService.getTenantUserRealm(tenantId);
-            return (AbstractUserStoreManager) realm.getUserStoreManager();
+
+            if (realm.getUserStoreManager().getSecondaryUserStoreManager() != null) {
+                userStoreManager = (AbstractUserStoreManager) realm.getUserStoreManager().getSecondaryUserStoreManager();
+            } else {
+                userStoreManager = (AbstractUserStoreManager) realm.getUserStoreManager();
+            }
         } catch (UserStoreException e) {
             handleException("Error while getting user store manager: " + e.getMessage(), e);
         }
-        return null;
+        return userStoreManager;
     }
 
     /**

--- a/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/utils/TokenExchangeUtils.java
+++ b/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/utils/TokenExchangeUtils.java
@@ -1190,8 +1190,10 @@ public class TokenExchangeUtils {
         try {
             UserRealm realm = (UserRealm) realmService.getTenantUserRealm(tenantId);
 
-            if (realm.getUserStoreManager().getSecondaryUserStoreManager() != null) {
-                userStoreManager = (AbstractUserStoreManager) realm.getUserStoreManager().getSecondaryUserStoreManager();
+            if (realm.getUserStoreManager().getSecondaryUserStoreManager() != null &&
+                    !shouldIncludePrimaryWhenSecondaryPresent()) {
+                userStoreManager =
+                        (AbstractUserStoreManager) realm.getUserStoreManager().getSecondaryUserStoreManager();
             } else {
                 userStoreManager = (AbstractUserStoreManager) realm.getUserStoreManager();
             }
@@ -1199,6 +1201,12 @@ public class TokenExchangeUtils {
             handleException("Error while getting user store manager: " + e.getMessage(), e);
         }
         return userStoreManager;
+    }
+
+    private static boolean shouldIncludePrimaryWhenSecondaryPresent() {
+
+        return Boolean.parseBoolean(IdentityUtil.getProperty(
+                Constants.INCLUDE_PRIMARY_WHEN_SECONDARY_PRESENT_IN_TOKEN_EXCHANGE_IMPLICIT_ASSOCIATION));
     }
 
     /**

--- a/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/utils/TokenExchangeUtils.java
+++ b/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/utils/TokenExchangeUtils.java
@@ -1180,7 +1180,6 @@ public class TokenExchangeUtils {
 
         RealmService realmService = TokenExchangeComponentServiceHolder.getInstance().getRealmService();
         String tenantDomain = tokReqMsgCtx.getOauth2AccessTokenReqDTO().getTenantDomain();
-        AbstractUserStoreManager userStoreManager = null;
 
         if (StringUtils.isEmpty(tenantDomain)) {
             tenantDomain = MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
@@ -1189,16 +1188,11 @@ public class TokenExchangeUtils {
 
         try {
             UserRealm realm = (UserRealm) realmService.getTenantUserRealm(tenantId);
-
-            if (realm.getUserStoreManager().getSecondaryUserStoreManager() != null) {
-                userStoreManager = (AbstractUserStoreManager) realm.getUserStoreManager().getSecondaryUserStoreManager();
-            } else {
-                userStoreManager = (AbstractUserStoreManager) realm.getUserStoreManager();
-            }
+            return (AbstractUserStoreManager) realm.getUserStoreManager();
         } catch (UserStoreException e) {
             handleException("Error while getting user store manager: " + e.getMessage(), e);
         }
-        return userStoreManager;
+        return null;
     }
 
     /**


### PR DESCRIPTION
### Purpose
Implement backend logic to honor a boolean config that determines whether the **PRIMARY user store** is included in the implicit-association search during **Token Exchange**. This behavior is evaluated **only when one or more secondary user stores are configured**.

### Goals
* Make inclusion of the **PRIMARY user store** during Token Exchange implicit association **configurable**.
* Preserve legacy behavior by default (skip PRIMARY) while allowing explicit opt-in.
* Keep scope limited to **Token Exchange implicit association**; no impact on other grants.
* Maintain safety by failing when the lookup claim is **not unique** across the considered stores.

### Approach
* Read the new boolean config at runtime.
* **Only if secondary stores are present**, choose the search start point based on the config:
  * **Include PRIMARY** → search **PRIMARY → secondary1 → secondary2 → …**
  * **Skip PRIMARY** (legacy) → start from the first **secondary**.
* Reuse existing iteration and uniqueness checks; add minimal debug logging for traceability.

---

### Related PRs
* *Server/config surface & defaults* → https://github.com/wso2/carbon-identity-framework/pull/7242
* *IS Docs: document across–user-store uniqueness for implicit association* → https://github.com/wso2/docs-is/pull/5540

### Related Issues
* Public Issue: https://github.com/wso2/product-is/issues/24798
