### PR TITLE
Add audience handling in token request message context

### DIFF
--- a/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandler.java
+++ b/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandler.java
@@ -689,6 +689,13 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
                 TokenExchangeUtils.handleClientException(Constants.TokenExchangeConstants.INVALID_TARGET,
                         "Invalid audience values provided");
             }
+            // set the audiences in the token request message context
+            if (requestedAudience != null && !requestedAudience.isEmpty()) {
+                List<String> audienceList = Arrays.stream(requestedAudience.split(","))
+                        .map(String::trim)
+                        .collect(Collectors.toList());
+                tokReqMsgCtx.setAudiences(audienceList);
+            }
 
             boolean customClaimsValidated = validateCustomClaims(claimsSet.getClaims(), identityProvider, params);
             if (!customClaimsValidated) {

--- a/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandler.java
+++ b/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandler.java
@@ -471,6 +471,9 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
     public OAuth2AccessTokenRespDTO issue(OAuthTokenReqMessageContext tokReqMsgCtx) throws IdentityOAuth2Exception {
 
         OAuth2AccessTokenRespDTO tokenRespDTO = super.issue(tokReqMsgCtx);
+        if (tokenRespDTO.isError()) {
+            return tokenRespDTO;
+        }
         AuthenticatedUser user = tokReqMsgCtx.getAuthorizedUser();
         Map<ClaimMapping, String> userAttributes = user.getUserAttributes();
         if (MapUtils.isNotEmpty(userAttributes)) {


### PR DESCRIPTION
This pull request adds logic to handle and store the audience values from the JWT subject token in the token request message context. This ensures that audience values provided in the request are properly parsed and set for downstream processing.

**Related PRs:** 
- https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/3000
- https://github.com/wso2/carbon-identity-framework/pull/7658