### PR TITLE
FIX: Support nested act claims and audience validation in Token Exchange grant

### DIFF
--- a/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/Constants.java
+++ b/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/Constants.java
@@ -64,6 +64,8 @@ public class Constants {
         public static final String ORG_ID = "org_id";
         public static final String SUB = "sub";
         public static final String SCOPE = "scope";
+        public static final String AZP = "azp";
+        public static final String CLIENT_ID = "client_id";
 
     }
 

--- a/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandler.java
+++ b/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandler.java
@@ -37,6 +37,7 @@ import org.wso2.carbon.identity.event.IdentityEventException;
 import org.wso2.carbon.identity.handler.event.account.lock.exception.AccountLockException;
 import org.wso2.carbon.identity.oauth.common.OAuth2ErrorCodes;
 import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
+import org.wso2.carbon.identity.oauth.dao.OAuthAppDO;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2AccessTokenRespDTO;
 import org.wso2.carbon.identity.oauth2.grant.token.exchange.Constants.TokenExchangeConstants;
@@ -54,14 +55,7 @@ import org.wso2.carbon.user.core.listener.UserOperationEventListener;
 import org.wso2.carbon.utils.DiagnosticLog;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.IMPERSONATED_SUBJECT;
@@ -82,6 +76,7 @@ import static org.wso2.carbon.identity.oauth2.grant.token.exchange.utils.TokenEx
 import static org.wso2.carbon.identity.oauth2.grant.token.exchange.utils.TokenExchangeUtils.setAuthorizedUserForImpersonation;
 import static org.wso2.carbon.identity.oauth2.grant.token.exchange.utils.TokenExchangeUtils.validateIssuedAtTime;
 import static org.wso2.carbon.identity.oauth2.grant.token.exchange.utils.TokenExchangeUtils.validateSignature;
+import static org.wso2.carbon.identity.oauth2.token.AccessTokenIssuer.OAUTH_APP_DO;
 import static org.wso2.carbon.identity.oauth2.util.OAuth2Util.isJWT;
 
 /**
@@ -111,12 +106,43 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
     }
 
     /**
+     * Recursively extracts all actor subjects from a nested act claim chain.
+     *
+     * @param actClaim The act claim object (can be nested)
+     * @return List of actor subjects in order from most recent to oldest
+     */
+    private List<String> extractActorChain(Object actClaim) {
+        List<String> actorChain = new ArrayList<>();
+
+        if (actClaim instanceof Map) {
+            Map<String, Object> actMap = (Map<String, Object>) actClaim;
+
+            // Get the subject at this level
+            Object subClaim = actMap.get("sub");
+            if (subClaim != null) {
+                actorChain.add(subClaim.toString());
+            }
+
+            // Recursively process nested act claim
+            Object nestedAct = actMap.get("act");
+            if (nestedAct != null) {
+                actorChain.addAll(extractActorChain(nestedAct));
+            }
+        }
+
+        return actorChain;
+    }
+
+
+    /**
      * Validate the Token Exchange Grant.
-     * Checks whether the token request satisfies the requirements to exchange the token.
+     * Checks whether the token request satisfies the requirements to exchange the
+     * token.
      *
      * @param tokReqMsgCtx OAuthTokenReqMessageContext
      * @return true or false if the grant_type is valid or not.
-     * @throws IdentityOAuth2Exception Error when validating the Token Exchange Grant
+     * @throws IdentityOAuth2Exception Error when validating the Token Exchange
+     *                                 Grant
      */
     @Override
     public boolean validateGrant(OAuthTokenReqMessageContext tokReqMsgCtx) throws IdentityOAuth2Exception {
@@ -134,11 +160,50 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
             requestedAudience = requestParams.get(Constants.TokenExchangeConstants.AUDIENCE);
         }
 
+        // Set requested audience in the token request context so JWTTokenIssuer can use it
+        if (StringUtils.isNotEmpty(requestedAudience)) {
+            // Parse comma-separated audiences if multiple are provided
+            List<String> requestedAudiences = Arrays.asList(requestedAudience.split(","))
+                    .stream()
+                    .map(String::trim)
+                    .filter(StringUtils::isNotEmpty)
+                    .collect(Collectors.toList());
+
+            if (!requestedAudiences.isEmpty()) {
+                validateRequestedAudience(tokReqMsgCtx, requestedAudiences);
+                tokReqMsgCtx.setAudiences(requestedAudiences);
+                if (log.isDebugEnabled()) {
+                    log.debug("Requested audiences in token exchange: " + requestedAudiences);
+                }
+            }
+        }
+
         String tenantDomain = getTenantDomain(tokReqMsgCtx);
 
-        // Check for self-delegation first (application exchanging its own token without actor)
+// Check for self-delegation first (application exchanging its own token without actor)
         if (isSelfDelegationRequest(requestParams, tokReqMsgCtx)) {
             validateSubjectTokenForSelfDelegation(tokReqMsgCtx, requestParams, tenantDomain);
+
+            // Check if subject token has an existing act claim
+            SignedJWT subjectSignedJWT = getSignedJWT(requestParams.get(TokenExchangeConstants.SUBJECT_TOKEN));
+            JWTClaimsSet subjectClaimsSet = getClaimSet(subjectSignedJWT);
+            Object existingActClaim = subjectClaimsSet.getClaim("act");
+
+            if (existingActClaim != null) {
+                // REMOVED: Authorization check - not needed for self-delegation
+                // In self-delegation, the token holder is refreshing their own token
+                // and should preserve the existing delegation chain
+
+                // Preserve existing act claim for self-delegation
+                tokReqMsgCtx.addProperty("IS_SELF_DELEGATION_WITH_ACT", true);
+                tokReqMsgCtx.addProperty("EXISTING_ACT_CLAIM", existingActClaim);
+
+                if (log.isDebugEnabled()) {
+                    List<String> actorChain = extractActorChain(existingActClaim);
+                    log.debug("Self-delegation preserving existing act claim chain: " + actorChain);
+                }
+            }
+
             // No need to validate actor token in self-delegation
             // Set impersonation flag to false for self-delegation
             tokReqMsgCtx.setImpersonationRequest(false);
@@ -146,6 +211,7 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
             return true;
         }
 
+        // Check for impersonation (subject token has may_act claim)
         if (isImpersonationRequest(requestParams)) {
             validateSubjectToken(tokReqMsgCtx, requestParams, tenantDomain);
             validateActorToken(tokReqMsgCtx, requestParams, tenantDomain);
@@ -154,10 +220,40 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
             setSubjectAsAuthorizedUser(tokReqMsgCtx, requestParams, tenantDomain);
             return true;
         }
+
+        // Check for delegation (actor token provided but no may_act in subject token)
+        if (isDelegationRequest(requestParams)) {
+            validateSubjectTokenForDelegation(tokReqMsgCtx, requestParams, tenantDomain);
+            validateActorTokenForDelegation(tokReqMsgCtx, requestParams, tenantDomain);
+            // Set impersonation flag to false for delegation
+            tokReqMsgCtx.setImpersonationRequest(false);
+            tokReqMsgCtx.addProperty("IS_DELEGATION_REQUEST", true);
+
+            // Extract and set actor subject from actor token
+            SignedJWT actorSignedJWT = getSignedJWT(requestParams.get(TokenExchangeConstants.ACTOR_TOKEN));
+            JWTClaimsSet actorClaimsSet = getClaimSet(actorSignedJWT);
+            String actorSubject = resolveSubject(actorClaimsSet);
+            tokReqMsgCtx.addProperty("ACTOR_SUBJECT", actorSubject);
+
+            // Check for existing act claim in subject token for nesting
+            SignedJWT subjectSignedJWT = getSignedJWT(requestParams.get(TokenExchangeConstants.SUBJECT_TOKEN));
+            JWTClaimsSet subjectClaimsSet = getClaimSet(subjectSignedJWT);
+            Object existingActClaim = subjectClaimsSet.getClaim("act");
+            if (existingActClaim != null) {
+                tokReqMsgCtx.addProperty("EXISTING_ACT_CLAIM", existingActClaim);
+                if (log.isDebugEnabled()) {
+                    List<String> existingActorChain = extractActorChain(existingActClaim);
+                    log.debug("Found existing act claim chain in subject token: " + existingActorChain);
+                    log.debug("Will nest under new actor: " + actorSubject);
+                }
+            }
+            setSubjectAsAuthorizedUser(tokReqMsgCtx, requestParams, tenantDomain);
+            return true;
+        }
         validateRequestedTokenType(requestedTokenType);
 
-        if (Constants.TokenExchangeConstants.JWT_TOKEN_TYPE.equals(subjectTokenType) || (Constants
-                .TokenExchangeConstants.ACCESS_TOKEN_TYPE.equals(subjectTokenType)) && isJWT(requestParams
+        if (Constants.TokenExchangeConstants.JWT_TOKEN_TYPE.equals(subjectTokenType)
+                || (Constants.TokenExchangeConstants.ACCESS_TOKEN_TYPE.equals(subjectTokenType)) && isJWT(requestParams
                 .get(Constants.TokenExchangeConstants.SUBJECT_TOKEN))) {
             handleJWTSubjectToken(requestParams, tokReqMsgCtx, tenantDomain, requestedAudience);
             if (tokReqMsgCtx.getAuthorizedUser() != null && !tokReqMsgCtx.getAuthorizedUser().isFederatedUser()) {
@@ -171,11 +267,59 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
     }
 
     /**
+     * Validates that the requested audience is allowed for the application.
+     *
+     * @param tokReqMsgCtx OAuthTokenReqMessageContext
+     * @param requestedAudiences Requested audiences
+     * @throws IdentityOAuth2Exception if validation fails
+     */
+    private void validateRequestedAudience(OAuthTokenReqMessageContext tokReqMsgCtx,
+                                           List<String> requestedAudiences)
+            throws IdentityOAuth2Exception {
+
+        if (requestedAudiences == null || requestedAudiences.isEmpty()) {
+            return;
+        }
+
+        // Get the OAuthAppDO to check allowed audiences
+        OAuthAppDO oAuthAppDO = (OAuthAppDO) tokReqMsgCtx.getProperty(OAUTH_APP_DO);
+        if (oAuthAppDO == null) {
+            // Try to load it
+            try {
+                String consumerKey = tokReqMsgCtx.getOauth2AccessTokenReqDTO().getClientId();
+                String tenantDomain = getTenantDomain(tokReqMsgCtx);
+                oAuthAppDO = OAuth2Util.getAppInformationByClientId(consumerKey, tenantDomain);
+            } catch (Exception e) {
+                handleException(OAuth2ErrorCodes.SERVER_ERROR,
+                        "Error while retrieving application information", e);
+            }
+        }
+
+        // Get allowed audiences for this application
+        List<String> allowedAudiences = OAuth2Util.getOIDCAudience(
+                tokReqMsgCtx.getOauth2AccessTokenReqDTO().getClientId(),
+                oAuthAppDO);
+
+        // Validate each requested audience
+        for (String requestedAud : requestedAudiences) {
+            if (!allowedAudiences.contains(requestedAud)) {
+                handleException(OAuth2ErrorCodes.INVALID_REQUEST,
+                        "Requested audience '" + requestedAud + "' is not allowed for this application. " +
+                                "Allowed audiences: " + String.join(", ", allowedAudiences));
+            }
+        }
+
+        if (log.isDebugEnabled()) {
+            log.debug("Requested audiences validated successfully: " + requestedAudiences);
+        }
+    }
+
+    /**
      * Checks if the token request is a self-delegation request where an application
      * is exchanging a token issued to itself, without requiring an actor token.
      *
      * @param requestParams A Map<String, String> containing the request parameters.
-     * @param tokReqMsgCtx OAuthTokenReqMessageContext
+     * @param tokReqMsgCtx  OAuthTokenReqMessageContext
      * @return true if the request is a self-delegation request, false otherwise.
      */
     private boolean isSelfDelegationRequest(Map<String, String> requestParams,
@@ -193,7 +337,8 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
             return false;
         }
 
-        // Verify that the subject token was issued to the same client making the request
+        // Verify that the subject token was issued to the same client making the
+        // request
         SignedJWT signedJWT = getSignedJWT(requestParams.get(TokenExchangeConstants.SUBJECT_TOKEN));
         if (signedJWT == null) {
             return false;
@@ -222,34 +367,76 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
     }
 
     /**
-     * Checks if the token request is an impersonation request by inspecting the provided request parameters.
+     * Checks if the token request is an impersonation request by inspecting the
+     * provided request parameters.
+     * For impersonation, the subject token MUST contain a may_act claim.
      *
      * @param requestParams A Map<String, String> containing the request parameters.
      * @return true if the request is an impersonation request and false otherwise.
      */
-    private boolean isImpersonationRequest(Map<String, String> requestParams) {
+    private boolean isImpersonationRequest(Map<String, String> requestParams) throws IdentityOAuth2Exception {
 
         // Check if all required parameters are present
-        return requestParams.containsKey(TokenExchangeConstants.SUBJECT_TOKEN)
-                && requestParams.containsKey(TokenExchangeConstants.SUBJECT_TOKEN_TYPE)
-                && requestParams.containsKey(TokenExchangeConstants.ACTOR_TOKEN)
-                && requestParams.containsKey(TokenExchangeConstants.ACTOR_TOKEN_TYPE);
+        if (!requestParams.containsKey(TokenExchangeConstants.SUBJECT_TOKEN) ||
+                !requestParams.containsKey(TokenExchangeConstants.SUBJECT_TOKEN_TYPE) ||
+                !requestParams.containsKey(TokenExchangeConstants.ACTOR_TOKEN) ||
+                !requestParams.containsKey(TokenExchangeConstants.ACTOR_TOKEN_TYPE)) {
+            return false;
+        }
+
+        // For impersonation, the subject token MUST have may_act claim
+        SignedJWT signedJWT = getSignedJWT(requestParams.get(TokenExchangeConstants.SUBJECT_TOKEN));
+        if (signedJWT == null) {
+            return false;
+        }
+
+        JWTClaimsSet claimsSet = getClaimSet(signedJWT);
+        if (claimsSet == null) {
+            return false;
+        }
+
+        // Check if may_act claim exists
+        return claimsSet.getClaim(MAY_ACT) != null;
+    }
+
+    /**
+     * Checks if the token request is a delegation request.
+     * Delegation occurs when actor_token is provided but subject token doesn't have
+     * may_act claim.
+     *
+     * @param requestParams A Map<String, String> containing the request parameters.
+     * @return true if the request is a delegation request and false otherwise.
+     */
+    private boolean isDelegationRequest(Map<String, String> requestParams) throws IdentityOAuth2Exception {
+
+        // Check if all required parameters are present
+        if (!requestParams.containsKey(TokenExchangeConstants.SUBJECT_TOKEN) ||
+                !requestParams.containsKey(TokenExchangeConstants.SUBJECT_TOKEN_TYPE) ||
+                !requestParams.containsKey(TokenExchangeConstants.ACTOR_TOKEN) ||
+                !requestParams.containsKey(TokenExchangeConstants.ACTOR_TOKEN_TYPE)) {
+            return false;
+        }
+
+        // For delegation, the subject token must NOT have may_act claim
+        SignedJWT signedJWT = getSignedJWT(requestParams.get(TokenExchangeConstants.SUBJECT_TOKEN));
+        if (signedJWT == null) {
+            return false;
+        }
+
+        JWTClaimsSet claimsSet = getClaimSet(signedJWT);
+        if (claimsSet == null) {
+            return false;
+        }
+
+        // Check if may_act claim does NOT exist
+        return claimsSet.getClaim(MAY_ACT) == null;
     }
 
     /**
      * Validates the subject token provided in the token exchange request.
      * Checks if the subject token is signed by the Authorization Server (AS),
-     * validates the token claims, and ensures it's intended for the correct audience and issuer.
-     *
-     * @param tokReqMsgCtx  OauthTokenReqMessageContext
-     * @param requestParams A Map<String, String> containing the request parameters.
-     * @param tenantDomain  The tenant domain associated with the request.
-     * @throws IdentityOAuth2Exception If there's an error during token validation.
-     */
-    /**
-     * Validates the subject token provided in the token exchange request.
-     * Checks if the subject token is signed by the Authorization Server (AS),
-     * validates the token claims, and ensures it's intended for the correct audience and issuer.
+     * validates the token claims, and ensures it's intended for the correct
+     * audience and issuer.
      *
      * @param tokReqMsgCtx  OauthTokenReqMessageContext
      * @param requestParams A Map<String, String> containing the request parameters.
@@ -331,7 +518,92 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
     }
 
     /**
-     * Validates the subject token for self-delegation scenarios where an application
+     * Validates the subject token for delegation scenarios.
+     * Unlike impersonation, delegation does NOT require a may_act claim in the
+     * subject token.
+     *
+     * @param tokReqMsgCtx  OauthTokenReqMessageContext
+     * @param requestParams A Map<String, String> containing the request parameters.
+     * @param tenantDomain  The tenant domain associated with the request.
+     * @throws IdentityOAuth2Exception If there's an error during token validation.
+     */
+    private void validateSubjectTokenForDelegation(OAuthTokenReqMessageContext tokReqMsgCtx,
+                                                   Map<String, String> requestParams,
+                                                   String tenantDomain)
+            throws IdentityOAuth2Exception {
+
+        // Retrieve the signed JWT object from the request parameters
+        SignedJWT signedJWT = getSignedJWT(requestParams.get(TokenExchangeConstants.SUBJECT_TOKEN));
+        if (signedJWT == null) {
+            handleException(OAuth2ErrorCodes.INVALID_REQUEST,
+                    "No Valid subject token was found for " + TokenExchangeConstants.TOKEN_EXCHANGE_GRANT_TYPE);
+        }
+
+        // Extract claims from the JWT
+        JWTClaimsSet claimsSet = getClaimSet(signedJWT);
+        if (claimsSet == null) {
+            handleException(OAuth2ErrorCodes.INVALID_REQUEST, "Claim values are empty in the given Subject Token");
+        }
+
+        // Validate mandatory claims
+        String subject = resolveSubject(claimsSet);
+        validateMandatoryClaims(claimsSet, subject);
+
+        // NOTE: We SKIP impersonator validation for delegation
+        // In delegation, there is no may_act claim because this is not impersonation
+
+        String jwtIssuer = claimsSet.getIssuer();
+        IdentityProvider identityProvider = getIdentityProvider(tokReqMsgCtx, jwtIssuer, tenantDomain);
+
+        try {
+            if (validateSignature(signedJWT, identityProvider, tenantDomain)) {
+                log.debug("Signature/MAC validated successfully for subject token.");
+            } else {
+                handleException(OAuth2ErrorCodes.INVALID_REQUEST, "Signature or Message Authentication "
+                        + "invalid for subject token.");
+            }
+        } catch (JOSEException e) {
+            handleException(OAuth2ErrorCodes.INVALID_REQUEST, "Error when verifying signature for subject token ", e);
+        }
+
+        checkJWTValidity(claimsSet);
+
+        // Validate the audience of the subject token
+        List<String> audiences = claimsSet.getAudience();
+
+        // Check if issuer is in the audience list
+        String idpIssuerName = OAuth2Util.getIssuerLocation(tenantDomain);
+        boolean issuerInAudience = audiences != null && audiences.contains(idpIssuerName);
+
+        if (!issuerInAudience) {
+            // Fallback: Check if the issuer alias value is present in audience
+            String idpAlias = getIDPAlias(identityProvider, tenantDomain);
+            if (StringUtils.isNotEmpty(idpAlias)) {
+                issuerInAudience = audiences.stream().anyMatch(aud -> aud.equals(idpAlias));
+            }
+
+            // If still not found in audience, validate the iss claim as fallback
+            if (!issuerInAudience) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Issuer not found in audience list. Validating iss claim as fallback.");
+                }
+                validateTokenIssuer(jwtIssuer, tenantDomain);
+            }
+        }
+
+        // Validate that requesting client is in the audience list
+        if (!validateSubjectTokenAudience(audiences, tokReqMsgCtx)) {
+            TokenExchangeUtils.handleClientException(TokenExchangeConstants.INVALID_TARGET,
+                    "Invalid audience values provided for subject token.");
+        }
+
+        tokReqMsgCtx.addProperty(IMPERSONATED_SUBJECT, subject);
+        tokReqMsgCtx.setScope(getScopes(claimsSet, tokReqMsgCtx));
+    }
+
+    /**
+     * Validates the subject token for self-delegation scenarios where an
+     * application
      * is exchanging a token issued to itself. Unlike impersonation, self-delegation
      * does not require a may_act claim.
      *
@@ -389,14 +661,14 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
         // 7. Check JWT validity (expiration time, not before time, issued at time)
         checkJWTValidity(claimsSet);
 
-    // 8. Validate the audience of the subject token
+        // 8. Validate the audience of the subject token
         List<String> audiences = claimsSet.getAudience();
         if (audiences == null || audiences.isEmpty()) {
             TokenExchangeUtils.handleClientException(TokenExchangeConstants.INVALID_TARGET,
                     "Audience is empty in the subject token.");
         }
 
-    // Check if issuer is in the audience list
+        // Check if issuer is in the audience list
         String idpIssuerName = OAuth2Util.getIssuerLocation(tenantDomain);
         boolean issuerInAudience = audiences.contains(idpIssuerName);
 
@@ -416,21 +688,22 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
             }
         }
 
-    // Validate that requesting client is in the audience list
+        // Validate that requesting client is in the audience list
         if (!validateSubjectTokenAudience(audiences, tokReqMsgCtx)) {
             TokenExchangeUtils.handleClientException(TokenExchangeConstants.INVALID_TARGET,
                     "Requesting client not found in audience list for subject token.");
         }
 
-    // 9. Set subject property in context
+        // 9. Set subject property in context
         tokReqMsgCtx.addProperty(IMPERSONATED_SUBJECT, subject);
 
-    // 10. Set scopes
+        // 10. Set scopes
         tokReqMsgCtx.setScope(getScopes(claimsSet, tokReqMsgCtx));
     }
 
     /**
-     * Retrieves the scopes claim from the JWTClaimsSet object and splits it into an array of individual scope strings.
+     * Retrieves the scopes claim from the JWTClaimsSet object and splits it into an
+     * array of individual scope strings.
      * Assumes that the scopes claim is represented as a space-delimited string.
      *
      * @param claimsSet    The JWTClaimsSet object containing the token claims.
@@ -463,12 +736,11 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
         return commonScopes.toArray(new String[0]);
     }
 
-
     private String resolveImpersonator(JWTClaimsSet claimsSet) {
 
         if (claimsSet.getClaim(MAY_ACT) != null) {
 
-            Map<String, String>  mayActClaimSet = (Map) claimsSet.getClaim(MAY_ACT);
+            Map<String, String> mayActClaimSet = (Map) claimsSet.getClaim(MAY_ACT);
             return mayActClaimSet.get(SUB);
         }
         return null;
@@ -477,7 +749,8 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
     /**
      * Validates the subject token provided in the token exchange request.
      * Checks if the subject token is signed by the Authorization Server (AS),
-     * validates the token claims, and ensures it's intended for the correct audience and issuer.
+     * validates the token claims, and ensures it's intended for the correct
+     * audience and issuer.
      *
      * @param tokReqMsgCtx  OauthTokenReqMessageContext
      * @param requestParams A Map<String, String> containing the request parameters.
@@ -533,6 +806,70 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
         tokReqMsgCtx.addProperty(IMPERSONATING_ACTOR, actorTokenSubject);
     }
 
+    /**
+     * Validates the actor token for delegation requests.
+     * Unlike impersonation, delegation does NOT require validating that the actor
+     * token subject
+     * matches an impersonator from the may_act claim, since delegation doesn't use
+     * may_act.
+     *
+     * @param tokReqMsgCtx  OauthTokenReqMessageContext
+     * @param requestParams A Map<String, String> containing the request parameters.
+     * @param tenantDomain  The tenant domain associated with the request.
+     * @throws IdentityOAuth2Exception If there's an error during token validation.
+     */
+    private void validateActorTokenForDelegation(OAuthTokenReqMessageContext tokReqMsgCtx,
+                                                 Map<String, String> requestParams,
+                                                 String tenantDomain)
+            throws IdentityOAuth2Exception {
+
+        // Retrieve the signed JWT object from the request parameters
+        SignedJWT signedJWT = getSignedJWT(requestParams.get(TokenExchangeConstants.ACTOR_TOKEN));
+        if (signedJWT == null) {
+            // If no valid actor token found, handle the exception
+            handleException(OAuth2ErrorCodes.INVALID_REQUEST, "No Valid actor token was found for "
+                    + TokenExchangeConstants.TOKEN_EXCHANGE_GRANT_TYPE);
+        }
+
+        // Extract claims from the JWT
+        JWTClaimsSet claimsSet = getClaimSet(signedJWT);
+        if (claimsSet == null) {
+            // If claim values are empty, handle the exception
+            handleException(OAuth2ErrorCodes.INVALID_REQUEST, "Claim values are empty in the given Actor Token");
+        }
+
+        // Validate mandatory claims
+        String actorTokenSubject = resolveSubject(claimsSet);
+        validateMandatoryClaims(claimsSet, actorTokenSubject);
+
+        // NOTE: For delegation, we skip the impersonator check since there's no may_act
+        // claim
+        // in the subject token. The actor is simply delegating on behalf of the
+        // subject.
+
+        String jwtIssuer = claimsSet.getIssuer();
+        IdentityProvider identityProvider = getIdentityProvider(tokReqMsgCtx, jwtIssuer, tenantDomain);
+
+        try {
+            if (validateSignature(signedJWT, identityProvider, tenantDomain)) {
+                log.debug("Signature/MAC validated successfully for actor token.");
+            } else {
+                handleException(OAuth2ErrorCodes.INVALID_REQUEST, "Signature or Message Authentication "
+                        + "invalid for actor token.");
+            }
+        } catch (JOSEException e) {
+            handleException(OAuth2ErrorCodes.INVALID_REQUEST, "Error when verifying signature for actor token ", e);
+        }
+
+        // Check the validity of the JWT
+        checkJWTValidity(claimsSet);
+
+        // Validate the issuer of the actor token
+        validateTokenIssuer(jwtIssuer, tenantDomain);
+
+        tokReqMsgCtx.addProperty(IMPERSONATING_ACTOR, actorTokenSubject);
+    }
+
     private void validateTokenIssuer(String jwtIssuer, String tenantDomain) throws IdentityOAuth2Exception {
 
         String expectedIssuer = OAuth2Util.getIdTokenIssuer(tenantDomain);
@@ -540,6 +877,7 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
             handleException(TokenExchangeConstants.INVALID_TARGET, "Invalid issuer values provided");
         }
     }
+
     private boolean validateSubjectTokenAudience(List<String> audiences,
                                                  OAuthTokenReqMessageContext tokenReqMessageContext) {
 
@@ -548,16 +886,24 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
     }
 
     /**
-     * Sets the authorized user for an OAuth token request context based on a subject token.
-     * This method extracts a signed JWT from the provided request parameters, validates it,
-     * and resolves the subject (user) contained within the JWT. It then sets the resolved subject
-     * as the authorized user in the OAuth token request context, specifically for impersonation scenarios.
+     * Sets the authorized user for an OAuth token request context based on a
+     * subject token.
+     * This method extracts a signed JWT from the provided request parameters,
+     * validates it,
+     * and resolves the subject (user) contained within the JWT. It then sets the
+     * resolved subject
+     * as the authorized user in the OAuth token request context, specifically for
+     * impersonation scenarios.
      *
-     * @param tokReqMsgCtx   The OAuth token request message context.
-     * @param requestParams  The map containing request parameters, including the subject token.
-     * @param tenantDomain   The tenant domain within which the identity provider and user reside.
-     * @throws IdentityOAuth2Exception if an error occurs while processing the subject token,
-     *                                  resolving the identity provider, or setting the authorized user.
+     * @param tokReqMsgCtx  The OAuth token request message context.
+     * @param requestParams The map containing request parameters, including the
+     *                      subject token.
+     * @param tenantDomain  The tenant domain within which the identity provider and
+     *                      user reside.
+     * @throws IdentityOAuth2Exception if an error occurs while processing the
+     *                                 subject token,
+     *                                 resolving the identity provider, or setting
+     *                                 the authorized user.
      */
     private void setSubjectAsAuthorizedUser(OAuthTokenReqMessageContext tokReqMsgCtx,
                                             Map<String, String> requestParams,
@@ -652,7 +998,8 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
      * Issue the Access token.
      *
      * @return <Code>OAuth2AccessTokenRespDTO</Code> representing the Access Token
-     * @throws IdentityOAuth2Exception Error when generating or persisting the access token
+     * @throws IdentityOAuth2Exception Error when generating or persisting the
+     *                                 access token
      */
     @Override
     public OAuth2AccessTokenRespDTO issue(OAuthTokenReqMessageContext tokReqMsgCtx) throws IdentityOAuth2Exception {
@@ -670,19 +1017,22 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
     /**
      * Returns if token exchange grant type could issue refresh tokens.
      *
-     * @return true | false if token exchange grant type can issue refresh tokens or not.
-     * @throws IdentityOAuth2Exception Error when checking if this grant type can issue refresh tokens or not
+     * @return true | false if token exchange grant type can issue refresh tokens or
+     *         not.
+     * @throws IdentityOAuth2Exception Error when checking if this grant type can
+     *                                 issue refresh tokens or not
      */
     @Override
     public boolean issueRefreshToken() throws IdentityOAuth2Exception {
 
-        return OAuthServerConfiguration.getInstance().getValueForIsRefreshTokenAllowed(Constants.TokenExchangeConstants
-                .TOKEN_EXCHANGE_GRANT_TYPE);
+        return OAuthServerConfiguration.getInstance()
+                .getValueForIsRefreshTokenAllowed(Constants.TokenExchangeConstants.TOKEN_EXCHANGE_GRANT_TYPE);
     }
 
     /**
      * Method to validate the custom claims.
-     * In order to write your own way of validation, you can extend this class and override this method.
+     * In order to write your own way of validation, you can extend this class and
+     * override this method.
      *
      * @param customClaims a map of custom claims
      * @param idp          - Identity Provider
@@ -697,7 +1047,8 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
 
     /**
      * Method to enrich the custom claims.
-     * In order to enrich custom claims to JWT, you can extend this class and override this method.
+     * In order to enrich custom claims to JWT, you can extend this class and
+     * override this method.
      *
      * @param customClaims a map of custom claims
      * @param idp          - Identity Provider
@@ -709,9 +1060,12 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
     }
 
     /**
-     * @deprecated Use {@link #validateAudience(List, IdentityProvider, String, RequestParameter[], String)} instead.
-     * Method to validate the audience value sent in the request.
-     * You can extend this class and override this method to add your validation logic.
+     * @deprecated Use
+     *             {@link #validateAudience(List, IdentityProvider, String, RequestParameter[], String)}
+     *             instead.
+     *             Method to validate the audience value sent in the request.
+     *             You can extend this class and override this method to add your
+     *             validation logic.
      *
      * @param audiences         - Audiences claims in JWT Type Token
      * @param idp               - Identity Provider
@@ -728,7 +1082,8 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
 
     /**
      * Method to validate the audience value sent in the request.
-     * You can extend this class and override this method to add your validation logic.
+     * You can extend this class and override this method to add your validation
+     * logic.
      *
      * @param audiences         - Audiences claims in JWT Type Token
      * @param idp               - Identity Provider
@@ -746,7 +1101,8 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
             return true;
         }
 
-        // If the audience is not found in the audiences claim, check if the issuer alias value is present.
+        // If the audience is not found in the audiences claim, check if the issuer
+        // alias value is present.
         String idpAlias = getIDPAlias(idp, tenantDomain);
         if (StringUtils.isEmpty(idpAlias)) {
             handleException(OAuth2ErrorCodes.INVALID_REQUEST, "Issuer name of the token issuer is not " +
@@ -758,7 +1114,8 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
 
     /**
      * The default implementation creates the subject from the Sub attribute.
-     * To translate between the federated and local user store, this may need some mapping.
+     * To translate between the federated and local user store, this may need some
+     * mapping.
      * Override if needed
      *
      * @param claimsSet all the JWT claims
@@ -771,6 +1128,7 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
 
     /**
      * Resolve subject user resident organization value.
+     *
      * @param claimsSet all the JWT claims.
      *
      * @return The organization of the subject user resides.
@@ -784,6 +1142,7 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
 
     /**
      * Resolve subject user accessing organization value.
+     *
      * @param claimsSet all the JWT claims.
      *
      * @return The organization of the subject user accessing.
@@ -812,11 +1171,9 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
 
     private void triggerAccountLinkFailedDiagnosticLog(String errorMessage) {
 
-        DiagnosticLog.DiagnosticLogBuilder diagnosticLogBuilder =
-                new DiagnosticLog.DiagnosticLogBuilder(
-                        Constants.LogConstants.COMPONENT_ID,
-                        Constants.LogConstants.ActionIDs.AUTHORIZE_LINKED_LOCAL_USER
-                );
+        DiagnosticLog.DiagnosticLogBuilder diagnosticLogBuilder = new DiagnosticLog.DiagnosticLogBuilder(
+                Constants.LogConstants.COMPONENT_ID,
+                Constants.LogConstants.ActionIDs.AUTHORIZE_LINKED_LOCAL_USER);
         diagnosticLogBuilder
                 .resultMessage(errorMessage)
                 .logDetailLevel(DiagnosticLog.LogDetailLevel.APPLICATION)

--- a/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandler.java
+++ b/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandler.java
@@ -234,6 +234,14 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
             JWTClaimsSet actorClaimsSet = getClaimSet(actorSignedJWT);
             String actorSubject = resolveSubject(actorClaimsSet);
             tokReqMsgCtx.addProperty("ACTOR_SUBJECT", actorSubject);
+            // Extract azp from actor token
+            Object actorAzpClaim = actorClaimsSet.getClaim(TokenExchangeConstants.AZP);
+            if (actorAzpClaim != null) {
+                tokReqMsgCtx.addProperty("ACTOR_AZP", actorAzpClaim.toString());
+                if (log.isDebugEnabled()) {
+                    log.debug("Actor AZP: " + actorAzpClaim.toString());
+                }
+            }
 
             // Check for existing act claim in subject token for nesting
             SignedJWT subjectSignedJWT = getSignedJWT(requestParams.get(TokenExchangeConstants.SUBJECT_TOKEN));

--- a/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandler.java
+++ b/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandler.java
@@ -773,8 +773,7 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
         SignedJWT signedJWT = getSignedJWT(requestParams.get(TokenExchangeConstants.ACTOR_TOKEN));
         if (signedJWT == null) {
             // If no valid subject token found, handle the exception
-            handleException(OAuth2ErrorCodes.INVALID_REQUEST, "No Valid subject token was found for "
-                    + TokenExchangeConstants.TOKEN_EXCHANGE_GRANT_TYPE);
+            handleException(OAuth2ErrorCodes.INVALID_REQUEST, "No Valid subject token was found for " + TokenExchangeConstants.TOKEN_EXCHANGE_GRANT_TYPE);
         }
 
         // Extract claims from the JWT
@@ -1033,8 +1032,7 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
     @Override
     public boolean issueRefreshToken() throws IdentityOAuth2Exception {
 
-        return OAuthServerConfiguration.getInstance()
-                .getValueForIsRefreshTokenAllowed(Constants.TokenExchangeConstants.TOKEN_EXCHANGE_GRANT_TYPE);
+        return OAuthServerConfiguration.getInstance().getValueForIsRefreshTokenAllowed(Constants.TokenExchangeConstants.TOKEN_EXCHANGE_GRANT_TYPE);
     }
 
     /**
@@ -1171,8 +1169,7 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
      * @return IdentityProvider with @jwtIssuer
      * @throws IdentityOAuth2Exception if an error occurred when getting IDP
      */
-    protected IdentityProvider getIdentityProvider(OAuthTokenReqMessageContext tokReqMsgCtx, String jwtIssuer,
-                                                   String tenantDomain) throws IdentityOAuth2Exception {
+    protected IdentityProvider getIdentityProvider(OAuthTokenReqMessageContext tokReqMsgCtx, String jwtIssuer, String tenantDomain) throws IdentityOAuth2Exception {
 
         return getIDP(jwtIssuer, tenantDomain);
     }

--- a/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandler.java
+++ b/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandler.java
@@ -93,6 +93,9 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
     private int validityPeriodInMin;
     private String requestedTokenType = Constants.TokenExchangeConstants.JWT_TOKEN_TYPE;
     private String impersonator;
+    private static final String ACTOR_SUBJECT = "actor_subject";
+    private static final String IS_DOWNSCOPING_REQUEST = "is_downscoping_request";
+    private static final String ACT = "act";
 
     /**
      * Initialize the TokenExchangeGrantHandler.
@@ -135,6 +138,25 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
         }
 
         String tenantDomain = getTenantDomain(tokReqMsgCtx);
+        // Parse the subject token early to determine the flow type
+        SignedJWT subjectSignedJWT = null;
+        JWTClaimsSet subjectClaimsSet = null;
+
+        if (Constants.TokenExchangeConstants.JWT_TOKEN_TYPE.equals(subjectTokenType) ||
+                (Constants.TokenExchangeConstants.ACCESS_TOKEN_TYPE.equals(subjectTokenType) &&
+                        isJWT(requestParams.get(Constants.TokenExchangeConstants.SUBJECT_TOKEN)))) {
+
+            subjectSignedJWT = getSignedJWT(requestParams.get(TokenExchangeConstants.SUBJECT_TOKEN));
+            if (subjectSignedJWT != null) {
+                subjectClaimsSet = getClaimSet(subjectSignedJWT);
+            }
+        }
+
+        // Check if this is a downscoping request (both tokens are access tokens, no may_act claim)
+        if (isDownscopingRequest(requestParams, subjectClaimsSet)) {
+            validateDownscopingRequest(tokReqMsgCtx, requestParams, tenantDomain, subjectSignedJWT, subjectClaimsSet);
+            return true;
+        }
         if (isImpersonationRequest(requestParams)) {
             validateSubjectToken(tokReqMsgCtx, requestParams, tenantDomain);
             validateActorToken(tokReqMsgCtx, requestParams, tenantDomain);
@@ -158,6 +180,149 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
         }
         return true;
     }
+    /**
+     * Validates a downscoping request where both subject_token and actor_token are access tokens.
+     * In this scenario, we validate both tokens and use the intersection of their scopes.
+     *
+     * @param tokReqMsgCtx  OauthTokenReqMessageContext
+     * @param requestParams A Map<String, String> containing the request parameters.
+     * @param tenantDomain  The tenant domain associated with the request.
+     * @param subjectSignedJWT The parsed subject token JWT.
+     * @param subjectClaimsSet The claims set from the subject token.
+     * @throws IdentityOAuth2Exception If there's an error during validation.
+     */
+
+    private void validateDownscopingRequest(OAuthTokenReqMessageContext tokReqMsgCtx,
+                                            Map<String, String> requestParams,
+                                            String tenantDomain,
+                                            SignedJWT subjectSignedJWT,
+                                            JWTClaimsSet subjectClaimsSet) throws IdentityOAuth2Exception {
+
+        if (subjectClaimsSet == null) {
+            handleException(OAuth2ErrorCodes.INVALID_REQUEST, "Claim values are empty in the given Subject Token");
+        }
+
+        // Validate subject token (access token)
+        String subjectTokenSubject = resolveSubject(subjectClaimsSet);
+        validateMandatoryClaims(subjectClaimsSet, subjectTokenSubject);
+
+        String jwtIssuer = subjectClaimsSet.getIssuer();
+        IdentityProvider identityProvider = getIdentityProvider(tokReqMsgCtx, jwtIssuer, tenantDomain);
+
+        try {
+            if (validateSignature(subjectSignedJWT, identityProvider, tenantDomain)) {
+                log.debug("Signature/MAC validated successfully for subject token.");
+            } else {
+                handleException(OAuth2ErrorCodes.INVALID_REQUEST,
+                        "Signature or Message Authentication invalid for subject token.");
+            }
+        } catch (JOSEException e) {
+            handleException(OAuth2ErrorCodes.INVALID_REQUEST, "Error when verifying signature for subject token ", e);
+        }
+
+        checkJWTValidity(subjectClaimsSet);
+        validateTokenIssuer(jwtIssuer, tenantDomain);
+
+        // **EXTRACT EXISTING ACT CLAIM FROM SUBJECT TOKEN ONLY**
+        Object existingActClaim = subjectClaimsSet.getClaim(ACT);
+
+        // Validate actor token
+        SignedJWT actorSignedJWT = getSignedJWT(requestParams.get(TokenExchangeConstants.ACTOR_TOKEN));
+        if (actorSignedJWT == null) {
+            handleException(OAuth2ErrorCodes.INVALID_REQUEST,
+                    "No Valid actor token was found for " + TokenExchangeConstants.TOKEN_EXCHANGE_GRANT_TYPE);
+        }
+
+        JWTClaimsSet actorClaimsSet = getClaimSet(actorSignedJWT);
+        if (actorClaimsSet == null) {
+            handleException(OAuth2ErrorCodes.INVALID_REQUEST, "Claim values are empty in the given Actor Token");
+        }
+
+        String actorTokenSubject = resolveSubject(actorClaimsSet);
+        validateMandatoryClaims(actorClaimsSet, actorTokenSubject);
+
+        String actorJwtIssuer = actorClaimsSet.getIssuer();
+        IdentityProvider actorIdentityProvider = getIdentityProvider(tokReqMsgCtx, actorJwtIssuer, tenantDomain);
+
+        try {
+            if (validateSignature(actorSignedJWT, actorIdentityProvider, tenantDomain)) {
+                log.debug("Signature/MAC validated successfully for actor token.");
+            } else {
+                handleException(OAuth2ErrorCodes.INVALID_REQUEST,
+                        "Signature or Message Authentication invalid for actor token.");
+            }
+        } catch (JOSEException e) {
+            handleException(OAuth2ErrorCodes.INVALID_REQUEST, "Error when verifying signature for actor token ", e);
+        }
+
+        checkJWTValidity(actorClaimsSet);
+        validateTokenIssuer(actorJwtIssuer, tenantDomain);
+
+        // For downscoping, set the subject from the subject token as the authorized user
+        String authorizedOrgId = resolveUserAccessingOrgId(subjectClaimsSet);
+        String userResideOrgId = resolveUserResideOrgId(subjectClaimsSet);
+
+        if (authorizedOrgId != null && userResideOrgId != null) {
+            setAuthorizedUserForImpersonation(
+                    tokReqMsgCtx, identityProvider, subjectTokenSubject, subjectClaimsSet,
+                    tenantDomain, authorizedOrgId, userResideOrgId);
+        } else {
+            setAuthorizedUserForImpersonation(
+                    tokReqMsgCtx, identityProvider, subjectTokenSubject, subjectClaimsSet, tenantDomain);
+        }
+
+        // Handle scope downscoping
+        String[] requestedScopes = tokReqMsgCtx.getOauth2AccessTokenReqDTO().getScope();
+        String[] subjectScopes = getScopes(subjectClaimsSet, tokReqMsgCtx);
+        String[] actorScopes = getScopes(actorClaimsSet, tokReqMsgCtx);
+        String[] finalScopes = calculateScopeIntersection(requestedScopes, subjectScopes, actorScopes);
+        tokReqMsgCtx.setScope(finalScopes);
+
+        // **STORE ONLY THE ACTOR'S SUBJECT (NOT THE ACTOR TOKEN'S ACT CLAIM)**
+        tokReqMsgCtx.addProperty(ACTOR_SUBJECT, actorTokenSubject);
+
+        // **STORE THE SUBJECT TOKEN'S EXISTING ACT CLAIM (IF PRESENT)**
+        if (existingActClaim != null) {
+            tokReqMsgCtx.addProperty("EXISTING_ACT_CLAIM", existingActClaim);
+            if (log.isDebugEnabled()) {
+                log.debug("Found existing act claim in subject token - will be nested in new token");
+            }
+        }
+
+        // Mark this as a downscoping request
+        tokReqMsgCtx.addProperty(IS_DOWNSCOPING_REQUEST, true);
+
+        if (log.isDebugEnabled()) {
+            log.debug("Downscoping request validated. Subject: " + subjectTokenSubject +
+                    ", Actor: " + actorTokenSubject +
+                    ", Has existing act claim from subject token: " + (existingActClaim != null) +
+                    ", Final scopes: " + String.join(" ", finalScopes));
+        }
+    }
+
+    /**
+     * Calculates scopes for downscoping request.
+     * For downscoping, we only check that requested scopes are available in the subject token.
+     * The actor token is used for authorization verification, not scope restriction.
+     *
+     * @param requestedScopes Scopes requested in the token exchange request
+     * @param subjectScopes Scopes present in the subject token
+     * @param actorScopes Scopes present in the actor token (not used for intersection)
+     * @return Scopes that are both requested and available in subject token
+     */
+    private String[] calculateScopeIntersection(String[] requestedScopes, String[] subjectScopes, String[] actorScopes) {
+
+        // If no scopes explicitly requested, return all subject token scopes
+        if (ArrayUtils.isEmpty(requestedScopes)) {
+            return subjectScopes;
+        }
+
+        // Return only requested scopes that exist in subject token
+        // Actor scopes are NOT checked - actor token proves authorization to downscope,
+        // but doesn't limit which scopes can be granted
+        return filterRequestedScopes(requestedScopes, subjectScopes);
+    }
+
 
     /**
      * Checks if the token request is an impersonation request by inspecting the provided request parameters.
@@ -172,6 +337,44 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
                 && requestParams.containsKey(TokenExchangeConstants.SUBJECT_TOKEN_TYPE)
                 && requestParams.containsKey(TokenExchangeConstants.ACTOR_TOKEN)
                 && requestParams.containsKey(TokenExchangeConstants.ACTOR_TOKEN_TYPE);
+    }
+
+    /**
+     * Checks if the token request is a downscoping request by inspecting the provided request parameters.
+     * Downscoping occurs when both subject_token and actor_token are present and are both access tokens,
+     * but the subject token does not contain a may_act claim (which would indicate an impersonation flow).
+     *
+     * @param requestParams A Map<String, String> containing the request parameters.
+     * @param subjectTokenClaimsSet The JWT claims set from the subject token.
+     * @return true if the request is a downscoping request and false otherwise.
+     */
+    private boolean isDownscopingRequest(Map<String, String> requestParams, JWTClaimsSet subjectTokenClaimsSet) {
+
+        // Check if all required parameters are present for token exchange
+        boolean hasRequiredParams = requestParams.containsKey(TokenExchangeConstants.SUBJECT_TOKEN)
+                && requestParams.containsKey(TokenExchangeConstants.SUBJECT_TOKEN_TYPE)
+                && requestParams.containsKey(TokenExchangeConstants.ACTOR_TOKEN)
+                && requestParams.containsKey(TokenExchangeConstants.ACTOR_TOKEN_TYPE);
+
+        if (!hasRequiredParams) {
+            return false;
+        }
+
+        // Check if both tokens are access tokens
+        String subjectTokenType = requestParams.get(TokenExchangeConstants.SUBJECT_TOKEN_TYPE);
+        String actorTokenType = requestParams.get(TokenExchangeConstants.ACTOR_TOKEN_TYPE);
+
+        boolean bothAccessTokens = TokenExchangeConstants.ACCESS_TOKEN_TYPE.equals(subjectTokenType)
+                && TokenExchangeConstants.ACCESS_TOKEN_TYPE.equals(actorTokenType);
+
+        if (!bothAccessTokens) {
+            return false;
+        }
+
+        // If both are access tokens, check if subject token has may_act claim
+        // If may_act is present, it's an impersonation flow
+        // If may_act is absent, it's a downscoping flow
+        return subjectTokenClaimsSet != null && subjectTokenClaimsSet.getClaim(MAY_ACT) == null;
     }
 
     /**
@@ -239,11 +442,6 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
         validateTokenIssuer(jwtIssuer, tenantDomain);
 
         tokReqMsgCtx.addProperty(IMPERSONATED_SUBJECT, subject);
-        if (claimsSet.getClaim("act") != null) {
-            tokReqMsgCtx.addProperty("act", claimsSet.getClaim("act"));
-        } else if (claimsSet.getClaim(MAY_ACT) != null) {
-            tokReqMsgCtx.addProperty(MAY_ACT, claimsSet.getClaim(MAY_ACT));
-        }
         tokReqMsgCtx.setScope(getScopes(claimsSet, tokReqMsgCtx));
     }
 
@@ -283,49 +481,14 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
 
 
     private String resolveImpersonator(JWTClaimsSet claimsSet) {
-        Object actClaim = claimsSet.getClaim("act");
-        if (actClaim != null) {
-            try {
-                if (actClaim instanceof Map) {
-                    Map<?, ?> actClaimSet = (Map<?, ?>) actClaim;
-                    Object subValue = actClaimSet.get(SUB);
-                    if (subValue != null) {
-                        return subValue.toString();
-                    }
-                } else {
-                    java.lang.reflect.Method getMethod = actClaim.getClass().getMethod("get", Object.class);
-                    Object subValue = getMethod.invoke(actClaim, SUB);
-                    if (subValue != null) {
-                        return subValue.toString();
-                    }
-                }
-            } catch (Exception e) {
-                if (log.isDebugEnabled()) {
-                    log.debug("Error while extracting subject from 'act' claim", e);
-                }
-            }
-        }
 
-        Object mayActClaim = claimsSet.getClaim(MAY_ACT);
-        if (mayActClaim != null) {
-            try {
-                if (mayActClaim instanceof Map) {
-                    Map<?, ?> mayActClaimSet = (Map<?, ?>) mayActClaim;
-                    Object subValue = mayActClaimSet.get(SUB);
-                    if (subValue != null) {
-                        return subValue.toString();
-                    }
-                }
-            } catch (Exception e) {
-                if (log.isDebugEnabled()) {
-                    log.debug("Error while extracting subject from 'may_act' claim", e);
-                }
-            }
-        }
+        if (claimsSet.getClaim(MAY_ACT) != null) {
 
+            Map<String, String>  mayActClaimSet = (Map) claimsSet.getClaim(MAY_ACT);
+            return mayActClaimSet.get(SUB);
+        }
         return null;
     }
-
 
     /**
      * Validates the subject token provided in the token exchange request.
@@ -346,7 +509,7 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
         if (signedJWT == null) {
             // If no valid subject token found, handle the exception
             handleException(OAuth2ErrorCodes.INVALID_REQUEST, "No Valid subject token was found for "
-                            + TokenExchangeConstants.TOKEN_EXCHANGE_GRANT_TYPE);
+                    + TokenExchangeConstants.TOKEN_EXCHANGE_GRANT_TYPE);
         }
 
         // Extract claims from the JWT
@@ -658,7 +821,7 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
      * @throws IdentityOAuth2Exception if an error occurred when getting IDP
      */
     protected IdentityProvider getIdentityProvider(OAuthTokenReqMessageContext tokReqMsgCtx, String jwtIssuer,
-            String tenantDomain) throws IdentityOAuth2Exception {
+                                                   String tenantDomain) throws IdentityOAuth2Exception {
 
         return getIDP(jwtIssuer, tenantDomain);
     }


### PR DESCRIPTION
### Proposed changes in this pull request

#### Support for Nested act/sub Claims in Token Exchange

- Added `extractActorChain()` utility method to recursively extract all actor subjects from nested `act` claim structures
- Modified `validateGrant()` to detect and preserve existing `act` claims from subject token:
  - Extracts existing `act` claim when present in subject token
  - Stores `EXISTING_ACT_CLAIM` in context for `JWTTokenIssuer` to nest under new actor
  - Logs complete actor chain for debugging delegation flows
- Enhanced `handleJWTSubjectToken()` to detect implicit delegation scenarios:
  - Detects when token issued to different client (`azp`) is exchanged by authorized party
  - Automatically sets `IS_DELEGATION_REQUEST` and `ACTOR_SUBJECT` properties
  - Preserves existing `act` claims for chained delegation

#### Fixed Self-Delegation Scenarios

- Implemented `isSelfDelegationRequest()` method to detect when application exchanges its own token:
  - Validates `azp` or `client_id` claim matches requesting client
  - Ensures no `actor_token` is provided
  - Returns true only when token was issued to same client making request
- Added `validateSubjectTokenForSelfDelegation()` with proper security validations:
  - JWT signature verification
  - Expiration, not-before, and issued-at time validation
  - Issuer validation with fallback mechanism
  - Mandatory claims validation
- Modified `validateGrant()` to preserve existing `act` claims during self-delegation:
  - Sets `IS_SELF_DELEGATION_WITH_ACT` flag when `act` claim exists
  - Stores entire nested `act` structure in context for preservation
- Removed incorrect `isAuthorizedForSelfDelegation()` method that was comparing token holder with previous actor

#### Support for Audience Parameter in Token Exchange Requests

- Added parsing of `audience` parameter from token exchange request
- Implemented `validateRequestedAudience()` method to validate requested audiences:
  - Retrieves application's allowed audiences from `OAuthAppDO`
  - Validates each requested audience against allowed list
  - Throws `invalid_request` error if audience not allowed
- Added support for comma-separated multiple audiences in request
- Sets validated audiences in `tokReqMsgCtx.setAudiences()` for JWT building

#### Fixed Issuer Validation When Issuer Not in Audience

- Enhanced audience validation logic in `validateSubjectToken()` with three-tier fallback:
  - First checks if IdP issuer name is in audience list
  - Falls back to checking IdP alias value in audience
  - Final fallback validates issuer (`iss`) claim directly
- Applied same fallback mechanism to `validateSubjectTokenForDelegation()`
- Applied same fallback mechanism to `validateSubjectTokenForSelfDelegation()`
- Removed incorrect validation requiring requesting client in audience for self-delegation

#### Enhanced Delegation Request Detection

- Added `isDelegationRequest()` method to detect delegation (actor_token present, no `may_act` claim)
- Added `isImpersonationRequest()` method to detect impersonation (requires `may_act` claim in subject token)
- Implemented `validateActorTokenForDelegation()` that skips impersonator validation (no `may_act` required for delegation)
- Modified `validateGrant()` to handle three distinct scenarios:
  - **Self-delegation**: Token holder refreshing own token
  - **Delegation**: Actor token provided, no `may_act` in subject token
  - **Impersonation**: Actor token provided, `may_act` present in subject token

#### Improved Logging

- Added detailed debug logging for delegation scenarios:
  - Self-delegation detection with actor chain preservation
  - Regular delegation with existing actor chain extraction
  - Implicit delegation detection
  - Nested `act` claim construction tracking


## Developer Checklist (Mandatory)

- [ ] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.



### Checklist (for reviewing)

#### General

- [x] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description.
- [x] **Is the PR labeled correctly?**

#### Functionality

- [x] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** N/A - Backend changes only

#### Code

- [x] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** N/A - No database changes
- [ ] **Are all necessary strings marked for translation?** N/A - No UI strings

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components.
- [ ] **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won't regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

#### Security

- [x] **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
- [ ] **Are all UI and API inputs run through forms or serializers?** All JWT tokens validated with signature checks
- [ ] **Are all external inputs validated and sanitized appropriately?** JWT validation includes signature, expiration, mandatory claims
- [ ] **Does all branching logic have a default case?** All delegation detection methods have proper fallbacks
- [ ] **Does this solution handle outliers and edge cases gracefully?** Self-delegation, implicit delegation, and chained delegation edge cases handled
- [x] **Are all external communications secured and restricted to SSL?** N/A - Token validation only
#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** N/A - No UI changes
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented.
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki.
