### PR TITLE
Implement the self delegation flow with azp claim inside the act/sub claim

### DIFF
--- a/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/Constants.java
+++ b/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/Constants.java
@@ -66,6 +66,7 @@ public class Constants {
         public static final String SCOPE = "scope";
         public static final String AZP = "azp";
         public static final String CLIENT_ID = "client_id";
+        public static final String ACT = "act";
 
     }
 

--- a/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/Constants.java
+++ b/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/Constants.java
@@ -64,6 +64,8 @@ public class Constants {
         public static final String ORG_ID = "org_id";
         public static final String SUB = "sub";
         public static final String SCOPE = "scope";
+        public static final String AZP = "azp";
+        public static final String CLIENT_ID = "client_id";
 
     }
 

--- a/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandler.java
+++ b/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandler.java
@@ -135,6 +135,33 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
         }
 
         String tenantDomain = getTenantDomain(tokReqMsgCtx);
+
+        // Check for self-delegation first (application exchanging its own token without actor)
+        if (isSelfDelegationRequest(requestParams, tokReqMsgCtx)) {
+            validateSubjectTokenForSelfDelegation(tokReqMsgCtx, requestParams, tenantDomain);
+
+            // Check if subject token has an existing act claim
+            SignedJWT subjectSignedJWT = getSignedJWT(requestParams.get(TokenExchangeConstants.SUBJECT_TOKEN));
+            JWTClaimsSet subjectClaimsSet = getClaimSet(subjectSignedJWT);
+            Object existingActClaim = subjectClaimsSet.getClaim("act");
+
+            if (existingActClaim != null) {
+                // REMOVED: Authorization check - not needed for self-delegation
+                // In self-delegation, the token holder is refreshing their own token
+                // and should preserve the existing delegation chain
+
+                // Preserve existing act claim for self-delegation
+                tokReqMsgCtx.addProperty("IS_SELF_DELEGATION_WITH_ACT", true);
+                tokReqMsgCtx.addProperty("EXISTING_ACT_CLAIM", existingActClaim);
+            }
+
+            // No need to validate actor token in self-delegation
+            // Set impersonation flag to false for self-delegation
+            tokReqMsgCtx.setImpersonationRequest(false);
+            setSubjectAsAuthorizedUser(tokReqMsgCtx, requestParams, tenantDomain);
+            return true;
+        }
+
         if (isImpersonationRequest(requestParams)) {
             validateSubjectToken(tokReqMsgCtx, requestParams, tenantDomain);
             validateActorToken(tokReqMsgCtx, requestParams, tenantDomain);
@@ -240,6 +267,159 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
 
         tokReqMsgCtx.addProperty(IMPERSONATED_SUBJECT, subject);
         tokReqMsgCtx.setScope(getScopes(claimsSet, tokReqMsgCtx));
+    }
+
+    /**
+     * Validates the subject token for self-delegation scenarios where an
+     * application
+     * is exchanging a token issued to itself. Unlike impersonation, self-delegation
+     * does not require a may_act claim.
+     *
+     * @param tokReqMsgCtx  OauthTokenReqMessageContext
+     * @param requestParams A Map<String, String> containing the request parameters.
+     * @param tenantDomain  The tenant domain associated with the request.
+     * @throws IdentityOAuth2Exception If there's an error during token validation.
+     */
+    private void validateSubjectTokenForSelfDelegation(OAuthTokenReqMessageContext tokReqMsgCtx,
+                                                       Map<String, String> requestParams,
+                                                       String tenantDomain)
+            throws IdentityOAuth2Exception {
+
+        // 1. Retrieve the signed JWT object from the request parameters
+        SignedJWT signedJWT = getSignedJWT(requestParams.get(TokenExchangeConstants.SUBJECT_TOKEN));
+        if (signedJWT == null) {
+            // If no valid subject token found, handle the exception
+            handleException(OAuth2ErrorCodes.INVALID_REQUEST,
+                    "No Valid subject token was found for " + TokenExchangeConstants.TOKEN_EXCHANGE_GRANT_TYPE);
+        }
+
+        // 2. Extract claims from the JWT
+        JWTClaimsSet claimsSet = getClaimSet(signedJWT);
+        if (claimsSet == null) {
+            // If claim values are empty, handle the exception
+            handleException(OAuth2ErrorCodes.INVALID_REQUEST, "Claim values are empty in the given Subject Token");
+        }
+
+        // 3. Validate mandatory claims (issuer, expiration time, subject, audience)
+        String subject = resolveSubject(claimsSet);
+        validateMandatoryClaims(claimsSet, subject);
+
+        // NOTE: We SKIP impersonator validation for self-delegation
+        // In self-delegation, there is no may_act claim because the application
+        // is exchanging its own token, not acting on behalf of another party
+
+        // 4. Get JWT issuer
+        String jwtIssuer = claimsSet.getIssuer();
+
+        // 5. Get identity provider
+        IdentityProvider identityProvider = getIdentityProvider(tokReqMsgCtx, jwtIssuer, tenantDomain);
+
+        // 6. Validate signature
+        try {
+            if (validateSignature(signedJWT, identityProvider, tenantDomain)) {
+                log.debug("Signature/MAC validated successfully for subject token.");
+            } else {
+                handleException(OAuth2ErrorCodes.INVALID_REQUEST, "Signature or Message Authentication "
+                        + "invalid for subject token.");
+            }
+        } catch (JOSEException e) {
+            handleException(OAuth2ErrorCodes.INVALID_REQUEST, "Error when verifying signature for subject token ", e);
+        }
+
+        // 7. Check JWT validity (expiration time, not before time, issued at time)
+        checkJWTValidity(claimsSet);
+
+        // 8. Validate the audience of the subject token
+        List<String> audiences = claimsSet.getAudience();
+        if (audiences == null || audiences.isEmpty()) {
+            TokenExchangeUtils.handleClientException(TokenExchangeConstants.INVALID_TARGET,
+                    "Audience is empty in the subject token.");
+        }
+
+        // Check if issuer is in the audience list
+        String idpIssuerName = OAuth2Util.getIssuerLocation(tenantDomain);
+        boolean issuerInAudience = audiences.contains(idpIssuerName);
+
+        if (!issuerInAudience) {
+            // Fallback: Check if the issuer alias value is present in audience
+            String idpAlias = getIDPAlias(identityProvider, tenantDomain);
+            if (StringUtils.isNotEmpty(idpAlias)) {
+                issuerInAudience = audiences.stream().anyMatch(aud -> aud.equals(idpAlias));
+            }
+
+            // If still not found in audience, validate the iss claim as fallback
+            if (!issuerInAudience) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Issuer not found in audience list. Validating iss claim as fallback.");
+                }
+                validateTokenIssuer(jwtIssuer, tenantDomain);
+            }
+        }
+
+        // Validate that requesting client is in the audience list
+        if (!validateSubjectTokenAudience(audiences, tokReqMsgCtx)) {
+            TokenExchangeUtils.handleClientException(TokenExchangeConstants.INVALID_TARGET,
+                    "Requesting client not found in audience list for subject token.");
+        }
+
+        // 9. Set subject property in context
+        tokReqMsgCtx.addProperty(IMPERSONATED_SUBJECT, subject);
+
+        // 10. Set scopes
+        tokReqMsgCtx.setScope(getScopes(claimsSet, tokReqMsgCtx));
+    }
+
+
+    /**
+     * Checks if the token request is a self-delegation request where an application
+     * is exchanging a token issued to itself, without requiring an actor token.
+     *
+     * @param requestParams A Map<String, String> containing the request parameters.
+     * @param tokReqMsgCtx  OAuthTokenReqMessageContext
+     * @return true if the request is a self-delegation request, false otherwise.
+     */
+    private boolean isSelfDelegationRequest(Map<String, String> requestParams,
+                                            OAuthTokenReqMessageContext tokReqMsgCtx)
+            throws IdentityOAuth2Exception {
+
+        // Must have subject_token and subject_token_type
+        if (!requestParams.containsKey(TokenExchangeConstants.SUBJECT_TOKEN) ||
+                !requestParams.containsKey(TokenExchangeConstants.SUBJECT_TOKEN_TYPE)) {
+            return false;
+        }
+
+        // Must NOT have actor_token (self-delegation doesn't need actor)
+        if (requestParams.containsKey(TokenExchangeConstants.ACTOR_TOKEN)) {
+            return false;
+        }
+
+        // Verify that the subject token was issued to the same client making the
+        // request
+        SignedJWT signedJWT = getSignedJWT(requestParams.get(TokenExchangeConstants.SUBJECT_TOKEN));
+        if (signedJWT == null) {
+            return false;
+        }
+
+        JWTClaimsSet claimsSet = getClaimSet(signedJWT);
+        if (claimsSet == null) {
+            return false;
+        }
+
+        String requestingClientId = tokReqMsgCtx.getOauth2AccessTokenReqDTO().getClientId();
+
+        // Check if the azp (authorized party) claim matches the requesting client
+        Object azpClaim = claimsSet.getClaim(TokenExchangeConstants.AZP);
+        if (azpClaim != null && azpClaim.toString().equals(requestingClientId)) {
+            return true;
+        }
+
+        // Check if the client_id claim matches the requesting client
+        Object clientIdClaim = claimsSet.getClaim(TokenExchangeConstants.CLIENT_ID);
+        if (clientIdClaim != null && clientIdClaim.toString().equals(requestingClientId)) {
+            return true;
+        }
+
+        return false;
     }
 
     /**

--- a/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandler.java
+++ b/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandler.java
@@ -382,7 +382,7 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
             return false;
         }
 
-        if (subjectClaimsSet == null) {                                             // ← no parsing, just null check
+        if (subjectClaimsSet == null) {
             return false;
         }
 


### PR DESCRIPTION
## Purpose  
Support **self-delegation** in OAuth2 Token Exchange (token exchange performed by the same actor) and ensure the **`azp` claim is included inside the `act` claim**.

## Description  
This PR improves token-exchange handling for self-delegation and strengthens validation logic:

- **Self-delegation detection**
  - Enhance `isSelfDelegationRequest()` to verify the token exchange request contains **only a subject token**, and that the **subject token was issued to the same client**.

- **Avoid `act` claim duplication**
  - Prevent duplicate `act` claim creation during token exchange by checking whether an **existing `act` claim** is already present.
  - If an `act` claim exists, **preserve it** instead of recreating/duplicating it.

- **Improve subject token validation**
  - Update `validateSubjectTokenForSelfDelegation()` to validate **mandatory JWT claims**.
  - Ensure the **issuer** is properly validated:
    - First, check whether the issuer appears in the **audience (`aud`) list**.
    - If not present, validate whether the **`iss` claim matches the JWT token’s issuer**.

- **Add constants**
  - Introduce constant variables `AZP` and `CLIENT_ID` in `Constants.java` for consistent claim handling.

## Sample (sanitized) token exchange request  
`POST https://localhost:9443/oauth2/token`

- `grant_type`: `urn:ietf:params:oauth:grant-type:token-exchange`  
- `subject_token`: `<JWT_ACCESS_TOKEN>`  
- `subject_token_type`: `urn:ietf:params:oauth:token-type:access_token`  
- `scope`: `booking:read`   

## Expected (sanitized) response claims  
- Includes `act.sub` and ensures `act.azp` is present under `act`
- Prevents duplicating `act` when already available
- Keeps `azp` and client binding consistent for self-delegation flows


