### PR TITLE
 Add delegation support to token exchange with chained act claims

### DIFF
--- a/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/pom.xml
+++ b/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/pom.xml
@@ -192,6 +192,8 @@
                             version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.handler.event.account.lock.exception;
                             version="${carbon.identity.account.lock.handler.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.handler.event.account.lock.service;
+                            version="${carbon.identity.account.lock.handler.imp.pkg.version.range}",
                             org.wso2.carbon.identity.application.mgt;
                             version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.event;

--- a/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/Constants.java
+++ b/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/Constants.java
@@ -68,6 +68,7 @@ public class Constants {
         public static final String SUB = "sub";
         public static final String SCOPE = "scope";
         public static final String SUBJECT_TOKEN_CLIENT_ID = "client_id";
+        public static final String AZP = "azp";
 
     }
 

--- a/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandler.java
+++ b/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandler.java
@@ -78,7 +78,6 @@ import static org.wso2.carbon.identity.oauth.common.OAuthConstants.DELEGATING_AC
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.EXISTING_ACT_CLAIM;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.IMPERSONATED_SUBJECT;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.IMPERSONATING_ACTOR;
-import static org.wso2.carbon.identity.oauth.common.OAuthConstants.IS_DELEGATION_REQUEST;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCClaims.AZP;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCClaims.CLIENT_ID;
 import static org.wso2.carbon.identity.oauth2.grant.token.exchange.Constants.TokenExchangeConstants.MAY_ACT;
@@ -159,58 +158,33 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
             // Impersonation: subject token has may_act, actor token is present and pre-authorized.
             validateSubjectToken(tokReqMsgCtx, requestParams, tenantDomain);
             validateActorToken(tokReqMsgCtx, requestParams, tenantDomain);
+            // Set impersonation flag
             tokReqMsgCtx.setImpersonationRequest(true);
             setSubjectAsAuthorizedUser(tokReqMsgCtx, requestParams, tenantDomain);
             return true;
 
         } else if (isDelegationRequest(requestParams, subjectClaimsSet, tokReqMsgCtx)) {
-            // Delegation (standard or self): subject token has no may_act.
-            // IS_DELEGATION_REQUEST is set here using OAuthConstants so JWTTokenIssuer
-            // reads the exact same property key and builds the act claim correctly.
+            // Delegation: subject token has no may_act; actor token present or same-client
+            // subject token with an existing act claim.
             validateSubjectTokenForDelegation(tokReqMsgCtx, requestParams, tenantDomain, subjectSignedJWT,
                     subjectClaimsSet);
-            tokReqMsgCtx.addProperty(IS_DELEGATION_REQUEST, true);
-
-            // Detect self-delegation: no actor token, and the subject token was issued to the
-            // requesting client (azp == currentClientId). The 'sub' may be a user UUID
-            String currentClientId = tokReqMsgCtx.getOauth2AccessTokenReqDTO().getClientId();
-            String tokenClientId = resolveTokenClientId(subjectClaimsSet);
-            boolean isSelfDelegation = tokenClientId != null
-                    && tokenClientId.equals(currentClientId)
-                    && !requestParams.containsKey(TokenExchangeConstants.ACTOR_TOKEN);
-
-            // Extract existing act claim from subject token once — used by both self and standard delegation.
+            tokReqMsgCtx.setDelegationRequest(true);
             Map<String, Object> existingActClaim = extractActClaim(subjectClaimsSet);
 
-            if (isSelfDelegation) {
-                // isDelegationRequest() guarantees existingActClaim is non-null for self-delegation.
-                // Carry the subject token's act claim forward as-is — the re-exchanging application
-                // must not alter the established delegation chain.
+            if (!requestParams.containsKey(TokenExchangeConstants.ACTOR_TOKEN)) {
+                // No new actor: isDelegationRequest() guarantees an existing act claim, which is carried
+                // forward unchanged so the re-exchanging application cannot alter the delegation chain.
+                String currentClientId = tokReqMsgCtx.getOauth2AccessTokenReqDTO().getClientId();
                 if (log.isDebugEnabled()) {
-                    log.debug("Processing self-delegation request. Current application '" + currentClientId
-                            + "' is implicitly acting as the actor. Carrying forward existing act claim.");
+                    log.debug("Delegation re-exchange without a new actor by application: " + currentClientId);
                 }
                 tokReqMsgCtx.addProperty(EXISTING_ACT_CLAIM, existingActClaim);
                 tokReqMsgCtx.addProperty(ACTOR_SUBJECT, existingActClaim.get(SUB));
                 tokReqMsgCtx.addProperty(DELEGATING_ACTOR, currentClientId);
             } else {
-                // Standard delegation: actor token is required; validate and extract subject from it.
+                // An actor token is present: validate it (parses the actor token once and sets the
+                // ACTOR_SUBJECT, ACTOR_AZP and DELEGATING_ACTOR properties).
                 validateActorTokenForDelegation(tokReqMsgCtx, requestParams, tenantDomain);
-
-                SignedJWT actorSignedJWT = getSignedJWT(requestParams.get(TokenExchangeConstants.ACTOR_TOKEN));
-                JWTClaimsSet actorClaimsSet = getClaimSet(actorSignedJWT);
-                String actorSubject = resolveSubject(actorClaimsSet);
-                if (log.isDebugEnabled()) {
-                    log.debug("Processing delegation request with actor subject: " + actorSubject);
-                }
-                tokReqMsgCtx.addProperty(ACTOR_SUBJECT, actorSubject);
-                Object actorAzpClaim = actorClaimsSet.getClaim(AZP);
-                if (actorAzpClaim != null) {
-                    tokReqMsgCtx.addProperty(ACTOR_AZP, actorAzpClaim.toString());
-                    if (log.isDebugEnabled()) {
-                        log.debug("Actor AZP: " + actorAzpClaim.toString());
-                    }
-                }
                 if (existingActClaim != null) {
                     tokReqMsgCtx.addProperty(EXISTING_ACT_CLAIM, existingActClaim);
                     if (log.isDebugEnabled()) {
@@ -268,17 +242,15 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
      * Checks if the token request is a delegation request.
      * Delegation occurs when:
      * <ul>
-     *   <li>An actor token is provided and the subject token has no may_act claim
-     *       (standard delegation), OR</li>
-     *   <li>No actor token is present but the subject token's client_id claim matches
-     *       the requesting client (self-delegation — the current application is
-     *       implicitly the actor).</li>
+     *   <li>An actor token is provided and the subject token has no may_act claim, OR</li>
+     *   <li>No actor token is present, but the subject token was issued to the requesting
+     *       client and already carries an act claim from a previous delegation</li>
      * </ul>
      *
      * @param requestParams    request parameter map.
      * @param subjectClaimsSet claims from the subject token.
      * @param tokReqMsgCtx     token request message context.
-     * @return true if the request is a delegation request (standard or self), false otherwise.
+     * @return true if the request is a delegation request, false otherwise.
      */
     private boolean isDelegationRequest(Map<String, String> requestParams, JWTClaimsSet subjectClaimsSet,
                                         OAuthTokenReqMessageContext tokReqMsgCtx) {
@@ -287,7 +259,6 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
                 !requestParams.containsKey(TokenExchangeConstants.SUBJECT_TOKEN_TYPE)) {
             return false;
         }
-
         if (subjectClaimsSet == null) {
             return false;
         }
@@ -297,16 +268,14 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
             return false;
         }
 
-        // Standard delegation: actor token present
+        // An actor token is present
         if (requestParams.containsKey(TokenExchangeConstants.ACTOR_TOKEN) &&
                 requestParams.containsKey(TokenExchangeConstants.ACTOR_TOKEN_TYPE)) {
             return true;
         }
 
-        // Self-delegation: no actor token, the subject token was issued to the requesting client
-        // (azp == currentClientId), AND the subject token already carries an act claim from a
-        // previous delegation. Without an existing act claim there is no delegation chain to carry
-        // forward — the request is treated as regular token exchange instead.
+        // No actor token: the subject token must have been issued to the requesting client
+        // and must already carry an act claim from a previous delegation.
         String currentClientId = tokReqMsgCtx.getOauth2AccessTokenReqDTO().getClientId();
         String tokenClientId = resolveTokenClientId(subjectClaimsSet);
         return tokenClientId != null
@@ -341,7 +310,7 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
         // Act exists but missing or blank required 'sub' = INVALID TOKEN
         if (actClaim.get(SUB) == null || StringUtils.isBlank(actClaim.get(SUB).toString())) {
             handleException(OAuth2ErrorCodes.INVALID_REQUEST,
-                    "Invalid act claim: missing required 'sub' field as per RFC 8693");
+                    "Invalid act claim: missing required 'sub' field");
         }
 
         return actClaim;
@@ -488,9 +457,6 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
         String subject = resolveSubject(claimsSet);
         validateMandatoryClaims(claimsSet, subject);
 
-        // NOTE: We SKIP impersonator validation for delegation
-        // In delegation, there is no may_act claim because this is not impersonation
-
         String jwtIssuer = claimsSet.getIssuer();
         IdentityProvider identityProvider = getIdentityProvider(tokReqMsgCtx, jwtIssuer, tenantDomain);
 
@@ -518,8 +484,6 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
         validateTokenIssuer(jwtIssuer, tenantDomain);
         tokReqMsgCtx.setScope(getScopes(claimsSet, tokReqMsgCtx));
     }
-
-
 
     /**
      * Retrieves the scopes claim from the JWTClaimsSet object and splits it into an array of individual scope strings.
@@ -701,6 +665,17 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
         // Verify the actor subject is a registered local user.
         validateActorSubject(tokReqMsgCtx, actorTokenSubject);
 
+        tokReqMsgCtx.addProperty(ACTOR_SUBJECT, actorTokenSubject);
+        if (log.isDebugEnabled()) {
+            log.debug("Processing delegation request with actor subject: " + actorTokenSubject);
+        }
+        Object actorAzpClaim = claimsSet.getClaim(AZP);
+        if (actorAzpClaim != null) {
+            tokReqMsgCtx.addProperty(ACTOR_AZP, actorAzpClaim.toString());
+            if (log.isDebugEnabled()) {
+                log.debug("Actor AZP: " + actorAzpClaim);
+            }
+        }
         tokReqMsgCtx.addProperty(DELEGATING_ACTOR, actorTokenSubject);
     }
 
@@ -711,6 +686,7 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
             handleException(TokenExchangeConstants.INVALID_TARGET, "Invalid issuer values provided");
         }
     }
+
     private boolean validateSubjectTokenAudience(List<String> audiences,
                                                  OAuthTokenReqMessageContext tokenReqMessageContext) {
 

--- a/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandler.java
+++ b/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandler.java
@@ -58,10 +58,10 @@ import org.wso2.carbon.user.api.UserStoreClientException;
 import org.wso2.carbon.user.core.UserStoreException;
 import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
 import org.wso2.carbon.user.core.listener.UserOperationEventListener;
+import org.wso2.carbon.user.core.util.UserCoreUtil;
 import org.wso2.carbon.utils.DiagnosticLog;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -76,6 +76,7 @@ import static org.wso2.carbon.identity.oauth.common.OAuthConstants.ACTOR_SUBJECT
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.EXISTING_ACT_CLAIM;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.IMPERSONATED_SUBJECT;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.IMPERSONATING_ACTOR;
+import static org.wso2.carbon.identity.oauth2.grant.token.exchange.Constants.TokenExchangeConstants.AZP;
 import static org.wso2.carbon.identity.oauth2.grant.token.exchange.Constants.TokenExchangeConstants.MAY_ACT;
 import static org.wso2.carbon.identity.oauth2.grant.token.exchange.Constants.TokenExchangeConstants.ORG_ID;
 import static org.wso2.carbon.identity.oauth2.grant.token.exchange.Constants.TokenExchangeConstants.SUB;
@@ -150,7 +151,7 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
         SignedJWT subjectSignedJWT = null;
         JWTClaimsSet subjectClaimsSet = null;
 
-        if (hasActorTokenParameters(requestParams)) {
+        if (hasSubjectAndActorTokenParameters(requestParams)) {
             subjectSignedJWT = getSignedJWT(requestParams.get(SUBJECT_TOKEN));
             if (subjectSignedJWT == null) {
                 handleException(OAuth2ErrorCodes.INVALID_REQUEST,
@@ -206,7 +207,7 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
                 if (existingActClaim != null) {
                     tokReqMsgCtx.addProperty(EXISTING_ACT_CLAIM, existingActClaim);
                     if (log.isDebugEnabled()) {
-                        log.debug("Found existing act claim chain: " + extractActorChain(existingActClaim));
+                        log.debug("Found an existing act claim chain.");
                     }
                 }
 
@@ -230,7 +231,7 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
      * @param requestParams request parameter map.
      * @return true if all four subject/actor token parameters are present.
      */
-    private boolean hasActorTokenParameters(Map<String, String> requestParams) {
+    private boolean hasSubjectAndActorTokenParameters(Map<String, String> requestParams) {
 
         return requestParams.containsKey(SUBJECT_TOKEN)
                 && requestParams.containsKey(TokenExchangeConstants.SUBJECT_TOKEN_TYPE)
@@ -308,39 +309,6 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
         }
 
         return actClaim;
-    }
-
-    /**
-     * Recursively extracts all actor subjects from a nested act claim chain.
-     *
-     * @param actClaim The act claim map (recursive structure)
-     * @return List of actor subjects in order from most recent to oldest
-     */
-    private List<String> extractActorChain(Map<String, Object> actClaim) {
-
-        List<String> actorChain = new ArrayList<>();
-
-        if (actClaim == null) {
-            if (log.isDebugEnabled()) {
-                log.debug("No act claim to extract - returning empty actor chain");
-            }
-            return actorChain;
-        }
-
-        // Extract the actor subject from the current delegation level and add to chain
-        Object subClaim = actClaim.get(SUB);
-        if (subClaim != null) {
-            actorChain.add(subClaim.toString());
-        }
-
-        // Recursively process nested act claim
-        Object nestedActRaw = actClaim.get(ACT);
-        if (nestedActRaw instanceof Map) {
-            Map<String, Object> nestedAct = (Map<String, Object>) nestedActRaw;
-            actorChain.addAll(extractActorChain(nestedAct));
-        }
-
-        return actorChain;
     }
 
     /**
@@ -568,8 +536,8 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
         // Validate the issuer of the actor token
         validateTokenIssuer(jwtIssuer, tenantDomain);
 
-        // Verify the actor subject is a registered local user.
-        validateActorSubject(tokReqMsgCtx, actorTokenSubject);
+        // Verify the actor subject resolves to a registered, active user.
+        validateActorSubject(tokReqMsgCtx, actorTokenSubject, claimsSet);
 
         // Determine the current top of the delegation chain (the most recent actor).
         String existingActorSubject = null;
@@ -581,10 +549,10 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
         if (!StringUtils.equals(actorTokenSubject, existingActorSubject)) {
             tokReqMsgCtx.addProperty(ACTOR_SUBJECT, actorTokenSubject);
             if (log.isDebugEnabled()) {
-                log.debug("Adding new delegation level for actor subject: " + actorTokenSubject);
+                log.debug("Adding a new delegation level for the actor token subject.");
             }
         } else if (log.isDebugEnabled()) {
-            log.debug("Actor '" + actorTokenSubject + "' matches the current top of the delegation chain; "
+            log.debug("Actor token subject matches the current top of the delegation chain; "
                     + "carrying the existing act claim forward unchanged.");
         }
     }
@@ -705,37 +673,73 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
         }
     }
 
-    private void validateActorSubject(OAuthTokenReqMessageContext tokReqMsgCtx, String actorSubject)
-            throws IdentityOAuth2Exception {
+    /**
+     * Validate that the actor token subject resolves to a registered, active user.
+     *
+     * @param tokReqMsgCtx  OAuth token request message context.
+     * @param actorSubject  Subject (sub) of the actor token.
+     * @param actorClaimsSet  Claim set of the actor token.
+     * @throws IdentityOAuth2Exception  Identity OAuth2 Exception.
+     */
+    private void validateActorSubject(OAuthTokenReqMessageContext tokReqMsgCtx, String actorSubject,
+                                      JWTClaimsSet actorClaimsSet) throws IdentityOAuth2Exception {
 
         if (StringUtils.isBlank(actorSubject)) {
-            handleException(OAuth2ErrorCodes.ACCESS_DENIED,
-                    "Actor token subject (sub) is missing or blank.");
+            handleException(OAuth2ErrorCodes.INVALID_REQUEST,
+                    "Mandatory field - Subject is empty in the given Actor Token");
         }
 
-        AbstractUserStoreManager userStoreManager = TokenExchangeUtils.getUserStoreManager(tokReqMsgCtx);
+        // Resolve the client id from the actor token
+        String clientId = actorClaimsSet.getClaim(AZP) != null ? actorClaimsSet.getClaim(AZP).toString() : null;
+        if (StringUtils.isBlank(clientId)) {
+            clientId = actorClaimsSet.getClaim(SUBJECT_TOKEN_CLIENT_ID) != null ?
+                    actorClaimsSet.getClaim(SUBJECT_TOKEN_CLIENT_ID).toString() : null;
+        }
+        if (StringUtils.isBlank(clientId)) {
+            handleException(OAuth2ErrorCodes.INVALID_REQUEST,
+                    "Unable to resolve the client id from the given Actor Token");
+        }
 
+        String tenantDomain = tokReqMsgCtx.getOauth2AccessTokenReqDTO().getTenantDomain();
+        String userName;
+        String userStoreDomain;
         try {
-            String resolvedUserName = userStoreManager.getUserNameFromUserID(actorSubject);
-            if (StringUtils.isNotBlank(resolvedUserName)) {
+            // Resolve the actor from the store using the application's subject claim.
+            AuthenticatedUser actor =
+                    OAuth2Util.getAuthenticatedUserFromSubjectIdentifier(actorSubject, tenantDomain, clientId);
+            userName = actor.getUserName();
+            userStoreDomain = actor.getUserStoreDomain();
+        } catch (IdentityOAuth2Exception e) {
+            /*
+             The subject could not be resolved by the application's subject claim.
+             Fall back to resolving it as a user id.
+             */
+            if (log.isDebugEnabled()) {
+                log.debug("Could not resolve the actor by the application's subject claim; retrying by treating "
+                        + "the subject as a user id.", e);
+            }
+            AbstractUserStoreManager userStoreManager = TokenExchangeUtils.getUserStoreManager(tokReqMsgCtx);
+            String domainQualifiedUserName;
+            try {
+                domainQualifiedUserName = userStoreManager.getUserNameFromUserID(actorSubject);
+            } catch (UserStoreException ex) {
+                handleException(OAuth2ErrorCodes.SERVER_ERROR, ex);
                 return;
             }
-        } catch (UserStoreException e) {
-            if (log.isDebugEnabled()) {
-                log.debug("Actor subject '" + actorSubject +
-                        "' did not resolve as a user ID; trying as a username.", e);
+            if (StringUtils.isBlank(domainQualifiedUserName)) {
+                handleException(OAuth2ErrorCodes.INVALID_REQUEST,
+                        "Actor token could not be resolved to a registered user.");
+                return;
             }
+            userStoreDomain = UserCoreUtil.extractDomainFromName(domainQualifiedUserName);
+            userName = UserCoreUtil.removeDomainFromName(domainQualifiedUserName);
         }
 
-        try {
-            if (!userStoreManager.isExistingUser(actorSubject)) {
-                handleException(OAuth2ErrorCodes.ACCESS_DENIED,
-                        "Actor token subject '" + actorSubject +
-                                "' is not a registered user in the identity store. " +
-                                "Delegation chain integrity cannot be guaranteed.");
-            }
-        } catch (UserStoreException e) {
-            handleException(OAuth2ErrorCodes.SERVER_ERROR, e);
+        // Validate that the actor account is active, neither locked nor disabled.
+        if (TokenExchangeUtils.isUserAccountLocked(userName, tenantDomain, userStoreDomain)
+                || TokenExchangeUtils.isUserAccountDisabled(userName, tenantDomain, userStoreDomain)) {
+            handleException(OAuth2ErrorCodes.ACCESS_DENIED,
+                    "Actor account is inactive.");
         }
     }
 

--- a/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandler.java
+++ b/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandler.java
@@ -166,9 +166,8 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
         } else if (isDelegationRequest(requestParams, subjectClaimsSet, tokReqMsgCtx)) {
             // Delegation: subject token has no may_act; actor token present or same-client
             // subject token with an existing act claim.
-            validateSubjectTokenForDelegation(tokReqMsgCtx, requestParams, tenantDomain, subjectSignedJWT,
-                    subjectClaimsSet);
             tokReqMsgCtx.setDelegationRequest(true);
+            handleJWTSubjectToken(requestParams, tokReqMsgCtx, tenantDomain, requestedAudience);
             Map<String, Object> existingActClaim = extractActClaim(subjectClaimsSet);
 
             if (!requestParams.containsKey(TokenExchangeConstants.ACTOR_TOKEN)) {
@@ -193,7 +192,6 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
                     }
                 }
             }
-            setSubjectAsAuthorizedUser(tokReqMsgCtx, requestParams, tenantDomain);
             return true;
 
         } else {
@@ -433,55 +431,6 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
         validateTokenIssuer(jwtIssuer, tenantDomain);
 
         tokReqMsgCtx.addProperty(IMPERSONATED_SUBJECT, subject);
-        tokReqMsgCtx.setScope(getScopes(claimsSet, tokReqMsgCtx));
-    }
-
-    /**
-     * Validates the subject token for delegation scenarios.
-     * Unlike impersonation, delegation does NOT require a may_act claim in the
-     * subject token.
-     *
-     * @param tokReqMsgCtx  OauthTokenReqMessageContext
-     * @param requestParams request parameter map.
-     * @param tenantDomain  The tenant domain associated with the request.
-     * @throws IdentityOAuth2Exception If there's an error during token validation.
-     */
-    private void validateSubjectTokenForDelegation(OAuthTokenReqMessageContext tokReqMsgCtx,
-                                                   Map<String, String> requestParams,
-                                                   String tenantDomain,
-                                                   SignedJWT signedJWT,
-                                                   JWTClaimsSet claimsSet)
-            throws IdentityOAuth2Exception {
-
-        // Validate mandatory claims
-        String subject = resolveSubject(claimsSet);
-        validateMandatoryClaims(claimsSet, subject);
-
-        String jwtIssuer = claimsSet.getIssuer();
-        IdentityProvider identityProvider = getIdentityProvider(tokReqMsgCtx, jwtIssuer, tenantDomain);
-
-        try {
-            if (validateSignature(signedJWT, identityProvider, tenantDomain)) {
-                log.debug("Signature/MAC validated successfully for subject token.");
-            } else {
-                handleException(OAuth2ErrorCodes.INVALID_REQUEST, "Signature or Message Authentication "
-                        + "invalid for subject token.");
-            }
-        } catch (JOSEException e) {
-            handleException(OAuth2ErrorCodes.INVALID_REQUEST, "Error when verifying signature for subject token ", e);
-        }
-
-        checkJWTValidity(claimsSet);
-
-        // Validate the audience of the subject token
-        List<String> audiences = claimsSet.getAudience();
-        if (!validateSubjectTokenAudience(audiences, tokReqMsgCtx)) {
-            TokenExchangeUtils.handleClientException(TokenExchangeConstants.INVALID_TARGET,
-                    "Invalid audience values provided for subject token.");
-        }
-
-        // Validate the issuer of the subject token
-        validateTokenIssuer(jwtIssuer, tenantDomain);
         tokReqMsgCtx.setScope(getScopes(claimsSet, tokReqMsgCtx));
     }
 

--- a/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandler.java
+++ b/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandler.java
@@ -1016,7 +1016,8 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
         RequestParameter[] params = tokReqMsgCtx.getOauth2AccessTokenReqDTO().getRequestParameters();
         // Skip the issuer-in-audience check for locally issued tokens; the local issuer is already trusted.
         if (!isLocalIdentityProvider) {
-            audienceFound = validateAudience(audiences, identityProvider, requestedAudience, params, tenantDomain);
+            boolean audienceFound = validateAudience(audiences, identityProvider, requestedAudience, params,
+                    tenantDomain);
             if (!audienceFound) {
                 TokenExchangeUtils.handleClientException(Constants.TokenExchangeConstants.INVALID_TARGET,
                         "Invalid audience values provided");

--- a/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandler.java
+++ b/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandler.java
@@ -960,9 +960,9 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
         List<String> audiences = claimsSet.getAudience();
         Map<String, Object> customClaims = new HashMap<>(claimsSet.getClaims());
 
+        validateMandatoryClaims(claimsSet, subject);
         tokReqMsgCtx.addProperty(Constants.EXPIRY_TIME, claimsSet.getExpirationTime());
 
-        validateMandatoryClaims(claimsSet, subject);
         identityProvider = getIdentityProvider(tokReqMsgCtx, jwtIssuer, tenantDomain);
 
         boolean isLocalIdentityProvider = Constants.LOCAL_IDP_NAME.equals(identityProvider.

--- a/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandler.java
+++ b/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandler.java
@@ -61,6 +61,7 @@ import org.wso2.carbon.user.core.listener.UserOperationEventListener;
 import org.wso2.carbon.utils.DiagnosticLog;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -70,11 +71,20 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.ACT;
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.ACTOR_AZP;
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.ACTOR_SUBJECT;
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.DELEGATING_ACTOR;
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.EXISTING_ACT_CLAIM;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.IMPERSONATED_SUBJECT;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.IMPERSONATING_ACTOR;
-import static org.wso2.carbon.identity.oauth.common.OAuthConstants.ORG_ID;
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.IS_DELEGATION_REQUEST;
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCClaims.AZP;
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCClaims.CLIENT_ID;
 import static org.wso2.carbon.identity.oauth2.grant.token.exchange.Constants.TokenExchangeConstants.MAY_ACT;
+import static org.wso2.carbon.identity.oauth2.grant.token.exchange.Constants.TokenExchangeConstants.ORG_ID;
 import static org.wso2.carbon.identity.oauth2.grant.token.exchange.Constants.TokenExchangeConstants.SUB;
+import static org.wso2.carbon.identity.oauth2.grant.token.exchange.Constants.TokenExchangeConstants.SUBJECT_TOKEN;
 import static org.wso2.carbon.identity.oauth2.grant.token.exchange.Constants.TokenExchangeConstants.SUBJECT_TOKEN_CLIENT_ID;
 import static org.wso2.carbon.identity.oauth2.grant.token.exchange.Constants.TokenExchangeConstants.USER_ORG;
 import static org.wso2.carbon.identity.oauth2.grant.token.exchange.utils.TokenExchangeUtils.checkExpirationTime;
@@ -142,26 +152,91 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
         }
 
         String tenantDomain = getTenantDomain(tokReqMsgCtx);
-        if (isImpersonationRequest(requestParams)) {
+        SignedJWT subjectSignedJWT = getSignedJWT(requestParams.get(SUBJECT_TOKEN));
+        JWTClaimsSet subjectClaimsSet = (subjectSignedJWT != null) ? getClaimSet(subjectSignedJWT) : null;
+
+        if (isImpersonationRequest(requestParams, subjectClaimsSet)) {
+            // Impersonation: subject token has may_act, actor token is present and pre-authorized.
             validateSubjectToken(tokReqMsgCtx, requestParams, tenantDomain);
             validateActorToken(tokReqMsgCtx, requestParams, tenantDomain);
-            // Set impersonation flag
             tokReqMsgCtx.setImpersonationRequest(true);
             setSubjectAsAuthorizedUser(tokReqMsgCtx, requestParams, tenantDomain);
             return true;
-        }
-        validateRequestedTokenType(requestedTokenType);
 
-        if (Constants.TokenExchangeConstants.JWT_TOKEN_TYPE.equals(subjectTokenType) || (Constants
-                .TokenExchangeConstants.ACCESS_TOKEN_TYPE.equals(subjectTokenType)) && isJWT(requestParams
-                .get(Constants.TokenExchangeConstants.SUBJECT_TOKEN))) {
-            handleJWTSubjectToken(requestParams, tokReqMsgCtx, tenantDomain, requestedAudience);
-            if (tokReqMsgCtx.getAuthorizedUser() != null && !tokReqMsgCtx.getAuthorizedUser().isFederatedUser()) {
-                validateLocalUser(tokReqMsgCtx, requestParams);
+        } else if (isDelegationRequest(requestParams, subjectClaimsSet, tokReqMsgCtx)) {
+            // Delegation (standard or self): subject token has no may_act.
+            // IS_DELEGATION_REQUEST is set here using OAuthConstants so JWTTokenIssuer
+            // reads the exact same property key and builds the act claim correctly.
+            validateSubjectTokenForDelegation(tokReqMsgCtx, requestParams, tenantDomain, subjectSignedJWT,
+                    subjectClaimsSet);
+            tokReqMsgCtx.addProperty(IS_DELEGATION_REQUEST, true);
+
+            // Detect self-delegation: no actor token, and the subject token was issued to the
+            // requesting client (azp == currentClientId). The 'sub' may be a user UUID
+            String currentClientId = tokReqMsgCtx.getOauth2AccessTokenReqDTO().getClientId();
+            String tokenClientId = resolveTokenClientId(subjectClaimsSet);
+            boolean isSelfDelegation = tokenClientId != null
+                    && tokenClientId.equals(currentClientId)
+                    && !requestParams.containsKey(TokenExchangeConstants.ACTOR_TOKEN);
+
+            // Extract existing act claim from subject token once — used by both self and standard delegation.
+            Map<String, Object> existingActClaim = extractActClaim(subjectClaimsSet);
+
+            if (isSelfDelegation) {
+                // isDelegationRequest() guarantees existingActClaim is non-null for self-delegation.
+                // Carry the subject token's act claim forward as-is — the re-exchanging application
+                // must not alter the established delegation chain.
+                if (log.isDebugEnabled()) {
+                    log.debug("Processing self-delegation request. Current application '" + currentClientId
+                            + "' is implicitly acting as the actor. Carrying forward existing act claim.");
+                }
+                tokReqMsgCtx.addProperty(EXISTING_ACT_CLAIM, existingActClaim);
+                tokReqMsgCtx.addProperty(ACTOR_SUBJECT, existingActClaim.get(SUB));
+                tokReqMsgCtx.addProperty(DELEGATING_ACTOR, currentClientId);
+            } else {
+                // Standard delegation: actor token is required; validate and extract subject from it.
+                validateActorTokenForDelegation(tokReqMsgCtx, requestParams, tenantDomain);
+
+                SignedJWT actorSignedJWT = getSignedJWT(requestParams.get(TokenExchangeConstants.ACTOR_TOKEN));
+                JWTClaimsSet actorClaimsSet = getClaimSet(actorSignedJWT);
+                String actorSubject = resolveSubject(actorClaimsSet);
+                if (log.isDebugEnabled()) {
+                    log.debug("Processing delegation request with actor subject: " + actorSubject);
+                }
+                tokReqMsgCtx.addProperty(ACTOR_SUBJECT, actorSubject);
+                Object actorAzpClaim = actorClaimsSet.getClaim(AZP);
+                if (actorAzpClaim != null) {
+                    tokReqMsgCtx.addProperty(ACTOR_AZP, actorAzpClaim.toString());
+                    if (log.isDebugEnabled()) {
+                        log.debug("Actor AZP: " + actorAzpClaim.toString());
+                    }
+                }
+                if (existingActClaim != null) {
+                    tokReqMsgCtx.addProperty(EXISTING_ACT_CLAIM, existingActClaim);
+                    if (log.isDebugEnabled()) {
+                        List<String> existingActorChain = extractActorChain(existingActClaim);
+                        log.debug("Found existing act claim chain: " + existingActorChain);
+                    }
+                }
             }
+            setSubjectAsAuthorizedUser(tokReqMsgCtx, requestParams, tenantDomain);
+            return true;
+
         } else {
-            handleException(OAuth2ErrorCodes.INVALID_REQUEST,
-                    "Unsupported subject token type : " + subjectTokenType + " provided");
+            // Generic JWT token exchange: neither impersonation nor delegation.
+            validateRequestedTokenType(requestedTokenType);
+
+            if (Constants.TokenExchangeConstants.JWT_TOKEN_TYPE.equals(subjectTokenType) || (Constants
+                    .TokenExchangeConstants.ACCESS_TOKEN_TYPE.equals(subjectTokenType)) && isJWT(requestParams
+                    .get(SUBJECT_TOKEN))) {
+                handleJWTSubjectToken(requestParams, tokReqMsgCtx, tenantDomain, requestedAudience);
+                if (tokReqMsgCtx.getAuthorizedUser() != null && !tokReqMsgCtx.getAuthorizedUser().isFederatedUser()) {
+                    validateLocalUser(tokReqMsgCtx, requestParams);
+                }
+            } else {
+                handleException(OAuth2ErrorCodes.INVALID_REQUEST,
+                        "Unsupported subject token type : " + subjectTokenType + " provided");
+            }
         }
         return true;
     }
@@ -172,13 +247,156 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
      * @param requestParams A Map<String, String> containing the request parameters.
      * @return true if the request is an impersonation request and false otherwise.
      */
-    private boolean isImpersonationRequest(Map<String, String> requestParams) {
+    private boolean isImpersonationRequest(Map<String, String> requestParams, JWTClaimsSet subjectClaimsSet) {
 
         // Check if all required parameters are present
-        return requestParams.containsKey(TokenExchangeConstants.SUBJECT_TOKEN)
-                && requestParams.containsKey(TokenExchangeConstants.SUBJECT_TOKEN_TYPE)
-                && requestParams.containsKey(TokenExchangeConstants.ACTOR_TOKEN)
-                && requestParams.containsKey(TokenExchangeConstants.ACTOR_TOKEN_TYPE);
+        if (!requestParams.containsKey(SUBJECT_TOKEN) ||
+                !requestParams.containsKey(TokenExchangeConstants.SUBJECT_TOKEN_TYPE) ||
+                !requestParams.containsKey(TokenExchangeConstants.ACTOR_TOKEN) ||
+                !requestParams.containsKey(TokenExchangeConstants.ACTOR_TOKEN_TYPE)) {
+            return false;
+        }
+
+        // For impersonation, the subject token MUST have may_act claim
+        if (subjectClaimsSet == null) {
+            return false;
+        }
+        return subjectClaimsSet.getClaim(MAY_ACT) != null;
+    }
+
+    /**
+     * Checks if the token request is a delegation request.
+     * Delegation occurs when:
+     * <ul>
+     *   <li>An actor token is provided and the subject token has no may_act claim
+     *       (standard delegation), OR</li>
+     *   <li>No actor token is present but the subject token's client_id claim matches
+     *       the requesting client (self-delegation — the current application is
+     *       implicitly the actor).</li>
+     * </ul>
+     *
+     * @param requestParams    request parameter map.
+     * @param subjectClaimsSet claims from the subject token.
+     * @param tokReqMsgCtx     token request message context.
+     * @return true if the request is a delegation request (standard or self), false otherwise.
+     */
+    private boolean isDelegationRequest(Map<String, String> requestParams, JWTClaimsSet subjectClaimsSet,
+                                        OAuthTokenReqMessageContext tokReqMsgCtx) {
+
+        if (!requestParams.containsKey(SUBJECT_TOKEN) ||
+                !requestParams.containsKey(TokenExchangeConstants.SUBJECT_TOKEN_TYPE)) {
+            return false;
+        }
+
+        if (subjectClaimsSet == null) {
+            return false;
+        }
+
+        // Subject token must not carry a may_act claim (that would be impersonation)
+        if (subjectClaimsSet.getClaim(MAY_ACT) != null) {
+            return false;
+        }
+
+        // Standard delegation: actor token present
+        if (requestParams.containsKey(TokenExchangeConstants.ACTOR_TOKEN) &&
+                requestParams.containsKey(TokenExchangeConstants.ACTOR_TOKEN_TYPE)) {
+            return true;
+        }
+
+        // Self-delegation: no actor token, the subject token was issued to the requesting client
+        // (azp == currentClientId), AND the subject token already carries an act claim from a
+        // previous delegation. Without an existing act claim there is no delegation chain to carry
+        // forward — the request is treated as regular token exchange instead.
+        String currentClientId = tokReqMsgCtx.getOauth2AccessTokenReqDTO().getClientId();
+        String tokenClientId = resolveTokenClientId(subjectClaimsSet);
+        return tokenClientId != null
+                && tokenClientId.equals(currentClientId)
+                && subjectClaimsSet.getClaim(ACT) != null;
+    }
+
+    /**
+     * Safely extracts and validates the act claim from a JWT claims set.
+     *
+     * @param claimsSet The JWT claims set
+     * @return The act claim as a Map, or null if no act claim is present
+     * @throws IdentityOAuth2Exception if the act claim is present but malformed
+     */
+    private Map<String, Object> extractActClaim(JWTClaimsSet claimsSet) throws IdentityOAuth2Exception {
+
+        Object rawActClaim = claimsSet.getClaim(ACT);
+
+        // No act claim = valid (no delegation)
+        if (rawActClaim == null) {
+            return null;
+        }
+
+        // Act exists but wrong type = INVALID TOKEN
+        if (!(rawActClaim instanceof Map)) {
+            handleException(OAuth2ErrorCodes.INVALID_REQUEST,
+                    "Invalid act claim: expected JSON object, got " + rawActClaim.getClass().getName());
+        }
+
+        Map<String, Object> actClaim = (Map<String, Object>) rawActClaim;
+
+        // Act exists but missing or blank required 'sub' = INVALID TOKEN
+        if (actClaim.get(SUB) == null || StringUtils.isBlank(actClaim.get(SUB).toString())) {
+            handleException(OAuth2ErrorCodes.INVALID_REQUEST,
+                    "Invalid act claim: missing required 'sub' field as per RFC 8693");
+        }
+
+        return actClaim;
+    }
+
+    /**
+     * Recursively extracts all actor subjects from a nested act claim chain.
+     *
+     * @param actClaim The act claim map (recursive structure)
+     * @return List of actor subjects in order from most recent to oldest
+     */
+    private List<String> extractActorChain(Map<String, Object> actClaim) {
+
+        List<String> actorChain = new ArrayList<>();
+
+        if (actClaim == null) {
+            if (log.isDebugEnabled()) {
+                log.debug("No act claim to extract - returning empty actor chain");
+            }
+            return actorChain;
+        }
+
+        // Extract the actor subject from the current delegation level and add to chain
+        Object subClaim = actClaim.get(SUB);
+        if (subClaim != null) {
+            actorChain.add(subClaim.toString());
+        }
+
+        // Recursively process nested act claim
+        Object nestedActRaw = actClaim.get(ACT);
+        if (nestedActRaw instanceof Map) {
+            Map<String, Object> nestedAct = (Map<String, Object>) nestedActRaw;
+            actorChain.addAll(extractActorChain(nestedAct));
+        }
+
+        return actorChain;
+    }
+
+    /**
+     * Resolves the client identifier from a JWT claims set.
+     * Checks the 'azp' (authorized party) claim first — which is how WSO2 IS stamps the
+     * issuing client on JWT access tokens — and falls back to the 'client_id' claim for
+     * tokens from other issuers.
+     *
+     * @param claimsSet JWT claims to inspect.
+     * @return the client identifier string, or {@code null} if neither claim is present.
+     */
+    private String resolveTokenClientId(JWTClaimsSet claimsSet) {
+
+        Object azp = claimsSet.getClaim(AZP);
+        if (azp != null) {
+            return azp.toString();
+        }
+        Object clientId = claimsSet.getClaim(CLIENT_ID);
+        return clientId != null ? clientId.toString() : null;
     }
 
     /**
@@ -196,7 +414,7 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
             throws IdentityOAuth2Exception {
 
         // Retrieve the signed JWT object from the request parameters
-        SignedJWT signedJWT = getSignedJWT(requestParams.get(TokenExchangeConstants.SUBJECT_TOKEN));
+        SignedJWT signedJWT = getSignedJWT(requestParams.get(SUBJECT_TOKEN));
         if (signedJWT == null) {
             // If no valid subject token found, handle the exception
             handleException(OAuth2ErrorCodes.INVALID_REQUEST,
@@ -248,6 +466,60 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
         tokReqMsgCtx.addProperty(IMPERSONATED_SUBJECT, subject);
         tokReqMsgCtx.setScope(getScopes(claimsSet, tokReqMsgCtx));
     }
+
+    /**
+     * Validates the subject token for delegation scenarios.
+     * Unlike impersonation, delegation does NOT require a may_act claim in the
+     * subject token.
+     *
+     * @param tokReqMsgCtx  OauthTokenReqMessageContext
+     * @param requestParams request parameter map.
+     * @param tenantDomain  The tenant domain associated with the request.
+     * @throws IdentityOAuth2Exception If there's an error during token validation.
+     */
+    private void validateSubjectTokenForDelegation(OAuthTokenReqMessageContext tokReqMsgCtx,
+                                                   Map<String, String> requestParams,
+                                                   String tenantDomain,
+                                                   SignedJWT signedJWT,
+                                                   JWTClaimsSet claimsSet)
+            throws IdentityOAuth2Exception {
+
+        // Validate mandatory claims
+        String subject = resolveSubject(claimsSet);
+        validateMandatoryClaims(claimsSet, subject);
+
+        // NOTE: We SKIP impersonator validation for delegation
+        // In delegation, there is no may_act claim because this is not impersonation
+
+        String jwtIssuer = claimsSet.getIssuer();
+        IdentityProvider identityProvider = getIdentityProvider(tokReqMsgCtx, jwtIssuer, tenantDomain);
+
+        try {
+            if (validateSignature(signedJWT, identityProvider, tenantDomain)) {
+                log.debug("Signature/MAC validated successfully for subject token.");
+            } else {
+                handleException(OAuth2ErrorCodes.INVALID_REQUEST, "Signature or Message Authentication "
+                        + "invalid for subject token.");
+            }
+        } catch (JOSEException e) {
+            handleException(OAuth2ErrorCodes.INVALID_REQUEST, "Error when verifying signature for subject token ", e);
+        }
+
+        checkJWTValidity(claimsSet);
+
+        // Validate the audience of the subject token
+        List<String> audiences = claimsSet.getAudience();
+        if (!validateSubjectTokenAudience(audiences, tokReqMsgCtx)) {
+            TokenExchangeUtils.handleClientException(TokenExchangeConstants.INVALID_TARGET,
+                    "Invalid audience values provided for subject token.");
+        }
+
+        // Validate the issuer of the subject token
+        validateTokenIssuer(jwtIssuer, tenantDomain);
+        tokReqMsgCtx.setScope(getScopes(claimsSet, tokReqMsgCtx));
+    }
+
+
 
     /**
      * Retrieves the scopes claim from the JWTClaimsSet object and splits it into an array of individual scope strings.
@@ -353,6 +625,85 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
         tokReqMsgCtx.addProperty(IMPERSONATING_ACTOR, actorTokenSubject);
     }
 
+    /**
+     * Validates the actor token for delegation requests.
+     * Unlike impersonation, delegation does NOT require validating that the actor
+     * token subject
+     * matches an impersonator from the may_act claim, since delegation doesn't use
+     * may_act.
+     *
+     * @param tokReqMsgCtx  OauthTokenReqMessageContext
+     * @param requestParams A Map<String, String> containing the request parameters.
+     * @param tenantDomain  The tenant domain associated with the request.
+     * @throws IdentityOAuth2Exception If there's an error during token validation.
+     */
+    private void validateActorTokenForDelegation(OAuthTokenReqMessageContext tokReqMsgCtx,
+                                                 Map<String, String> requestParams,
+                                                 String tenantDomain)
+            throws IdentityOAuth2Exception {
+
+        // Only JWT-based access tokens are accepted as actor tokens.
+        // Generic JWT type is excluded to prevent ID tokens from being used as actor tokens.
+        String actorTokenType = requestParams.get(TokenExchangeConstants.ACTOR_TOKEN_TYPE);
+        if (!TokenExchangeConstants.ACCESS_TOKEN_TYPE.equals(actorTokenType)) {
+            handleException(OAuth2ErrorCodes.INVALID_REQUEST,
+                    "Unsupported actor token type: " + actorTokenType
+                            + ". Supported type: " + TokenExchangeConstants.ACCESS_TOKEN_TYPE);
+        }
+
+        // The access token must be a JWT.
+        if (!isJWT(requestParams.get(TokenExchangeConstants.ACTOR_TOKEN))) {
+            handleException(OAuth2ErrorCodes.INVALID_REQUEST,
+                    "Actor token type is " + TokenExchangeConstants.ACCESS_TOKEN_TYPE
+                            + " but the provided token is not a JWT. Only JWT-based access tokens are supported.");
+        }
+
+        // Retrieve the signed JWT object from the request parameters
+        SignedJWT signedJWT = getSignedJWT(requestParams.get(TokenExchangeConstants.ACTOR_TOKEN));
+        if (signedJWT == null) {
+            // If no valid actor token found, handle the exception
+            handleException(OAuth2ErrorCodes.INVALID_REQUEST, "No Valid actor token was found for "
+                    + TokenExchangeConstants.TOKEN_EXCHANGE_GRANT_TYPE);
+        }
+
+        // Extract claims from the JWT
+        JWTClaimsSet claimsSet = getClaimSet(signedJWT);
+        if (claimsSet == null) {
+            // If claim values are empty, handle the exception
+            handleException(OAuth2ErrorCodes.INVALID_REQUEST, "Claim values are empty in the given Actor Token");
+        }
+
+        // Validate mandatory claims
+        String actorTokenSubject = resolveSubject(claimsSet);
+        validateMandatoryClaims(claimsSet, actorTokenSubject);
+
+
+        String jwtIssuer = claimsSet.getIssuer();
+        IdentityProvider identityProvider = getIdentityProvider(tokReqMsgCtx, jwtIssuer, tenantDomain);
+
+        try {
+            if (validateSignature(signedJWT, identityProvider, tenantDomain)) {
+                log.debug("Signature/MAC validated successfully for actor token.");
+            } else {
+                handleException(OAuth2ErrorCodes.INVALID_REQUEST, "Signature or Message Authentication "
+                        + "invalid for actor token.");
+            }
+        } catch (JOSEException e) {
+            handleException(OAuth2ErrorCodes.INVALID_REQUEST, "Error when verifying signature for actor token ", e);
+        }
+
+        // Check the validity of the JWT
+        checkJWTValidity(claimsSet);
+
+        // Validate the issuer of the actor token
+        validateTokenIssuer(jwtIssuer, tenantDomain);
+
+        // Verify the actor subject is a registered local user.
+        validateActorSubject(tokReqMsgCtx, actorTokenSubject);
+
+        tokReqMsgCtx.addProperty(DELEGATING_ACTOR, actorTokenSubject);
+    }
+
     private void validateTokenIssuer(String jwtIssuer, String tenantDomain) throws IdentityOAuth2Exception {
 
         String expectedIssuer = OAuth2Util.getIdTokenIssuer(tenantDomain);
@@ -383,7 +734,7 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
                                             Map<String, String> requestParams,
                                             String tenantDomain) throws IdentityOAuth2Exception {
 
-        SignedJWT signedJWT = getSignedJWT(requestParams.get(TokenExchangeConstants.SUBJECT_TOKEN));
+        SignedJWT signedJWT = getSignedJWT(requestParams.get(SUBJECT_TOKEN));
 
         JWTClaimsSet claimsSet = getClaimSet(signedJWT);
         String jwtIssuer = claimsSet.getIssuer();
@@ -465,6 +816,40 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
             } finally {
                 IdentityUtil.threadLocalProperties.get().remove(IdentityCoreConstants.SKIP_LOCAL_USER_CLAIM_UPDATE);
             }
+        }
+    }
+
+    private void validateActorSubject(OAuthTokenReqMessageContext tokReqMsgCtx, String actorSubject)
+            throws IdentityOAuth2Exception {
+
+        if (StringUtils.isBlank(actorSubject)) {
+            handleException(OAuth2ErrorCodes.ACCESS_DENIED,
+                    "Actor token subject (sub) is missing or blank.");
+        }
+
+        AbstractUserStoreManager userStoreManager = TokenExchangeUtils.getUserStoreManager(tokReqMsgCtx);
+
+        try {
+            String resolvedUserName = userStoreManager.getUserNameFromUserID(actorSubject);
+            if (StringUtils.isNotBlank(resolvedUserName)) {
+                return;
+            }
+        } catch (UserStoreException e) {
+            if (log.isDebugEnabled()) {
+                log.debug("Actor subject '" + actorSubject +
+                        "' did not resolve as a user ID; trying as a username.", e);
+            }
+        }
+
+        try {
+            if (!userStoreManager.isExistingUser(actorSubject)) {
+                handleException(OAuth2ErrorCodes.ACCESS_DENIED,
+                        "Actor token subject '" + actorSubject +
+                                "' is not a registered user in the identity store. " +
+                                "Delegation chain integrity cannot be guaranteed.");
+            }
+        } catch (UserStoreException e) {
+            handleException(OAuth2ErrorCodes.SERVER_ERROR, e);
         }
     }
 
@@ -641,7 +1026,7 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
     }
 
     /**
-     * Default implementation to get IDP from the issuer name in a specific tenant
+     * Default implementation to get IDP from the issuer name in a specific tenant.
      *
      * @param tokReqMsgCtx OAuthTokenReqMessageContext to extract more information
      * @param jwtIssuer    issuer of the IDP
@@ -685,7 +1070,7 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
         IdentityProvider identityProvider;
         JWTClaimsSet claimsSet;
 
-        signedJWT = getSignedJWT(requestParams.get(Constants.TokenExchangeConstants.SUBJECT_TOKEN));
+        signedJWT = getSignedJWT(requestParams.get(SUBJECT_TOKEN));
         if (signedJWT != null) {
             claimsSet = getClaimSet(signedJWT);
             if (claimsSet == null) {

--- a/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandler.java
+++ b/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandler.java
@@ -72,14 +72,10 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.ACT;
-import static org.wso2.carbon.identity.oauth.common.OAuthConstants.ACTOR_AZP;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.ACTOR_SUBJECT;
-import static org.wso2.carbon.identity.oauth.common.OAuthConstants.DELEGATING_ACTOR;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.EXISTING_ACT_CLAIM;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.IMPERSONATED_SUBJECT;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.IMPERSONATING_ACTOR;
-import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCClaims.AZP;
-import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCClaims.CLIENT_ID;
 import static org.wso2.carbon.identity.oauth2.grant.token.exchange.Constants.TokenExchangeConstants.MAY_ACT;
 import static org.wso2.carbon.identity.oauth2.grant.token.exchange.Constants.TokenExchangeConstants.ORG_ID;
 import static org.wso2.carbon.identity.oauth2.grant.token.exchange.Constants.TokenExchangeConstants.SUB;
@@ -163,34 +159,26 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
             setSubjectAsAuthorizedUser(tokReqMsgCtx, requestParams, tenantDomain);
             return true;
 
-        } else if (isDelegationRequest(requestParams, subjectClaimsSet, tokReqMsgCtx)) {
-            // Delegation: subject token has no may_act; actor token present or same-client
-            // subject token with an existing act claim.
+        } else if (isDelegationRequest(requestParams, subjectClaimsSet)) {
+            // Delegation: subject token has act claim or new actor token is present.
             tokReqMsgCtx.setDelegationRequest(true);
             handleJWTSubjectToken(requestParams, tokReqMsgCtx, tenantDomain, requestedAudience);
-            Map<String, Object> existingActClaim = extractActClaim(subjectClaimsSet);
+            if (tokReqMsgCtx.getAuthorizedUser() != null && !tokReqMsgCtx.getAuthorizedUser().isFederatedUser()) {
+                validateLocalUser(tokReqMsgCtx, requestParams);
+            }
 
-            if (!requestParams.containsKey(TokenExchangeConstants.ACTOR_TOKEN)) {
-                // No new actor: isDelegationRequest() guarantees an existing act claim, which is carried
-                // forward unchanged so the re-exchanging application cannot alter the delegation chain.
-                String currentClientId = tokReqMsgCtx.getOauth2AccessTokenReqDTO().getClientId();
-                if (log.isDebugEnabled()) {
-                    log.debug("Delegation re-exchange without a new actor by application: " + currentClientId);
-                }
+            // Preserve any existing act claim from a previous delegation as the base of the chain.
+            Map<String, Object> existingActClaim = extractActClaim(subjectClaimsSet);
+            if (existingActClaim != null) {
                 tokReqMsgCtx.addProperty(EXISTING_ACT_CLAIM, existingActClaim);
-                tokReqMsgCtx.addProperty(ACTOR_SUBJECT, existingActClaim.get(SUB));
-                tokReqMsgCtx.addProperty(DELEGATING_ACTOR, currentClientId);
-            } else {
-                // An actor token is present: validate it (parses the actor token once and sets the
-                // ACTOR_SUBJECT, ACTOR_AZP and DELEGATING_ACTOR properties).
-                validateActorTokenForDelegation(tokReqMsgCtx, requestParams, tenantDomain);
-                if (existingActClaim != null) {
-                    tokReqMsgCtx.addProperty(EXISTING_ACT_CLAIM, existingActClaim);
-                    if (log.isDebugEnabled()) {
-                        List<String> existingActorChain = extractActorChain(existingActClaim);
-                        log.debug("Found existing act claim chain: " + existingActorChain);
-                    }
+                if (log.isDebugEnabled()) {
+                    log.debug("Found existing act claim chain: " + extractActorChain(existingActClaim));
                 }
+            }
+
+            // A new actor token, when present, adds the next level to the delegation chain.
+            if (requestParams.containsKey(TokenExchangeConstants.ACTOR_TOKEN)) {
+                validateActorTokenForDelegation(tokReqMsgCtx, requestParams, tenantDomain, existingActClaim);
             }
             return true;
 
@@ -238,20 +226,17 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
 
     /**
      * Checks if the token request is a delegation request.
-     * Delegation occurs when:
+     * Delegation occurs when the subject token has no may_act claim and either:
      * <ul>
-     *   <li>An actor token is provided and the subject token has no may_act claim, OR</li>
-     *   <li>No actor token is present, but the subject token was issued to the requesting
-     *       client and already carries an act claim from a previous delegation</li>
+     *   <li>The subject token already carries an act claim from a previous delegation, OR</li>
+     *   <li>A new actor token is presented.</li>
      * </ul>
      *
      * @param requestParams    request parameter map.
      * @param subjectClaimsSet claims from the subject token.
-     * @param tokReqMsgCtx     token request message context.
      * @return true if the request is a delegation request, false otherwise.
      */
-    private boolean isDelegationRequest(Map<String, String> requestParams, JWTClaimsSet subjectClaimsSet,
-                                        OAuthTokenReqMessageContext tokReqMsgCtx) {
+    private boolean isDelegationRequest(Map<String, String> requestParams, JWTClaimsSet subjectClaimsSet) {
 
         if (!requestParams.containsKey(SUBJECT_TOKEN) ||
                 !requestParams.containsKey(TokenExchangeConstants.SUBJECT_TOKEN_TYPE)) {
@@ -265,20 +250,14 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
         if (subjectClaimsSet.getClaim(MAY_ACT) != null) {
             return false;
         }
-
-        // An actor token is present
-        if (requestParams.containsKey(TokenExchangeConstants.ACTOR_TOKEN) &&
-                requestParams.containsKey(TokenExchangeConstants.ACTOR_TOKEN_TYPE)) {
+        // The subject token already carries an act claim from a previous delegation.
+        if (subjectClaimsSet.getClaim(ACT) != null) {
             return true;
         }
 
-        // No actor token: the subject token must have been issued to the requesting client
-        // and must already carry an act claim from a previous delegation.
-        String currentClientId = tokReqMsgCtx.getOauth2AccessTokenReqDTO().getClientId();
-        String tokenClientId = resolveTokenClientId(subjectClaimsSet);
-        return tokenClientId != null
-                && tokenClientId.equals(currentClientId)
-                && subjectClaimsSet.getClaim(ACT) != null;
+        // Otherwise, delegation requires a new actor token to be presented.
+        return requestParams.containsKey(TokenExchangeConstants.ACTOR_TOKEN) &&
+                requestParams.containsKey(TokenExchangeConstants.ACTOR_TOKEN_TYPE);
     }
 
     /**
@@ -345,25 +324,6 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
         }
 
         return actorChain;
-    }
-
-    /**
-     * Resolves the client identifier from a JWT claims set.
-     * Checks the 'azp' (authorized party) claim first — which is how WSO2 IS stamps the
-     * issuing client on JWT access tokens — and falls back to the 'client_id' claim for
-     * tokens from other issuers.
-     *
-     * @param claimsSet JWT claims to inspect.
-     * @return the client identifier string, or {@code null} if neither claim is present.
-     */
-    private String resolveTokenClientId(JWTClaimsSet claimsSet) {
-
-        Object azp = claimsSet.getClaim(AZP);
-        if (azp != null) {
-            return azp.toString();
-        }
-        Object clientId = claimsSet.getClaim(CLIENT_ID);
-        return clientId != null ? clientId.toString() : null;
     }
 
     /**
@@ -545,14 +505,17 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
      * matches an impersonator from the may_act claim, since delegation doesn't use
      * may_act.
      *
-     * @param tokReqMsgCtx  OauthTokenReqMessageContext
-     * @param requestParams A Map<String, String> containing the request parameters.
-     * @param tenantDomain  The tenant domain associated with the request.
+     * @param tokReqMsgCtx    OauthTokenReqMessageContext
+     * @param requestParams   A Map<String, String> containing the request parameters.
+     * @param tenantDomain    The tenant domain associated with the request.
+     * @param existingActClaim The act claim already present on the subject token (the current
+     *                         delegation chain), or {@code null} if there is none.
      * @throws IdentityOAuth2Exception If there's an error during token validation.
      */
     private void validateActorTokenForDelegation(OAuthTokenReqMessageContext tokReqMsgCtx,
                                                  Map<String, String> requestParams,
-                                                 String tenantDomain)
+                                                 String tenantDomain,
+                                                 Map<String, Object> existingActClaim)
             throws IdentityOAuth2Exception {
 
         // Only JWT-based access tokens are accepted as actor tokens.
@@ -614,18 +577,22 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
         // Verify the actor subject is a registered local user.
         validateActorSubject(tokReqMsgCtx, actorTokenSubject);
 
-        tokReqMsgCtx.addProperty(ACTOR_SUBJECT, actorTokenSubject);
-        if (log.isDebugEnabled()) {
-            log.debug("Processing delegation request with actor subject: " + actorTokenSubject);
+        // Determine the current top of the delegation chain (the most recent actor).
+        String existingActorSubject = null;
+        if (existingActClaim != null && existingActClaim.get(SUB) != null) {
+            existingActorSubject = existingActClaim.get(SUB).toString();
         }
-        Object actorAzpClaim = claimsSet.getClaim(AZP);
-        if (actorAzpClaim != null) {
-            tokReqMsgCtx.addProperty(ACTOR_AZP, actorAzpClaim.toString());
+
+        // Only add a new delegation level when the actor differs from the current top of the chain.
+        if (!StringUtils.equals(actorTokenSubject, existingActorSubject)) {
+            tokReqMsgCtx.addProperty(ACTOR_SUBJECT, actorTokenSubject);
             if (log.isDebugEnabled()) {
-                log.debug("Actor AZP: " + actorAzpClaim);
+                log.debug("Adding new delegation level for actor subject: " + actorTokenSubject);
             }
+        } else if (log.isDebugEnabled()) {
+            log.debug("Actor '" + actorTokenSubject + "' matches the current top of the delegation chain; "
+                    + "carrying the existing act claim forward unchanged.");
         }
-        tokReqMsgCtx.addProperty(DELEGATING_ACTOR, actorTokenSubject);
     }
 
     private void validateTokenIssuer(String jwtIssuer, String tenantDomain) throws IdentityOAuth2Exception {

--- a/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandler.java
+++ b/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandler.java
@@ -147,80 +147,106 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
         }
 
         String tenantDomain = getTenantDomain(tokReqMsgCtx);
-        SignedJWT subjectSignedJWT = getSignedJWT(requestParams.get(SUBJECT_TOKEN));
-        JWTClaimsSet subjectClaimsSet = (subjectSignedJWT != null) ? getClaimSet(subjectSignedJWT) : null;
+        SignedJWT subjectSignedJWT = null;
+        JWTClaimsSet subjectClaimsSet = null;
 
-        if (isImpersonationRequest(requestParams, subjectClaimsSet)) {
-            // Impersonation: subject token has may_act, actor token is present and pre-authorized.
-            validateSubjectToken(tokReqMsgCtx, requestParams, tenantDomain);
-            validateActorToken(tokReqMsgCtx, requestParams, tenantDomain);
-            // Set impersonation flag
-            tokReqMsgCtx.setImpersonationRequest(true);
-            setSubjectAsAuthorizedUser(tokReqMsgCtx, requestParams, tenantDomain);
-            return true;
+        if (hasActorTokenParameters(requestParams)) {
+            subjectSignedJWT = getSignedJWT(requestParams.get(SUBJECT_TOKEN));
+            if (subjectSignedJWT == null) {
+                handleException(OAuth2ErrorCodes.INVALID_REQUEST,
+                        "No Valid subject token was found for " + TokenExchangeConstants.TOKEN_EXCHANGE_GRANT_TYPE);
+            }
+            subjectClaimsSet = getClaimSet(subjectSignedJWT);
+            if (subjectClaimsSet == null) {
+                handleException(OAuth2ErrorCodes.INVALID_REQUEST, "Claim values are empty in the given Subject Token");
+            }
 
-        } else if (isDelegationRequest(requestParams, subjectClaimsSet)) {
-            // Delegation: subject token has act claim or new actor token is present.
-            tokReqMsgCtx.setDelegationRequest(true);
-            handleJWTSubjectToken(requestParams, tokReqMsgCtx, tenantDomain, requestedAudience);
+            if (isImpersonationRequest(subjectClaimsSet)) {
+                // Impersonation: subject token has may_act, actor token is present and pre-authorized.
+                validateSubjectToken(tokReqMsgCtx, tenantDomain, subjectSignedJWT, subjectClaimsSet);
+                validateActorToken(tokReqMsgCtx, requestParams, tenantDomain);
+                tokReqMsgCtx.setImpersonationRequest(true);
+                setSubjectAsAuthorizedUser(tokReqMsgCtx, requestParams, tenantDomain);
+                return true;
+            }
+        }
+
+        validateRequestedTokenType(requestedTokenType);
+
+        if (Constants.TokenExchangeConstants.JWT_TOKEN_TYPE.equals(subjectTokenType) || (Constants
+                .TokenExchangeConstants.ACCESS_TOKEN_TYPE.equals(subjectTokenType)) && isJWT(requestParams
+                .get(SUBJECT_TOKEN))) {
+            if (subjectClaimsSet == null) {
+                subjectSignedJWT = getSignedJWT(requestParams.get(SUBJECT_TOKEN));
+                if (subjectSignedJWT == null) {
+                    handleException(OAuth2ErrorCodes.INVALID_REQUEST, "No Valid subject token was found for "
+                            + TokenExchangeConstants.TOKEN_EXCHANGE_GRANT_TYPE);
+                }
+                subjectClaimsSet = getClaimSet(subjectSignedJWT);
+                if (subjectClaimsSet == null) {
+                    handleException(OAuth2ErrorCodes.INVALID_REQUEST,
+                            "Claim values are empty in the given JSON Web Token");
+                }
+            }
+
+            boolean delegationRequest = isDelegationRequest(requestParams, subjectClaimsSet);
+            if (delegationRequest) {
+                // Delegation: subject token has act claim or new actor token is present.
+                tokReqMsgCtx.setDelegationRequest(true);
+            }
+
+            handleJWTSubjectToken(tokReqMsgCtx, tenantDomain, requestedAudience, subjectSignedJWT, subjectClaimsSet);
             if (tokReqMsgCtx.getAuthorizedUser() != null && !tokReqMsgCtx.getAuthorizedUser().isFederatedUser()) {
                 validateLocalUser(tokReqMsgCtx, requestParams);
             }
 
-            // Preserve any existing act claim from a previous delegation as the base of the chain.
-            Map<String, Object> existingActClaim = extractActClaim(subjectClaimsSet);
-            if (existingActClaim != null) {
-                tokReqMsgCtx.addProperty(EXISTING_ACT_CLAIM, existingActClaim);
-                if (log.isDebugEnabled()) {
-                    log.debug("Found existing act claim chain: " + extractActorChain(existingActClaim));
+            if (delegationRequest) {
+                // Preserve any existing act claim from a previous delegation as the base of the chain.
+                Map<String, Object> existingActClaim = extractActClaim(subjectClaimsSet);
+                if (existingActClaim != null) {
+                    tokReqMsgCtx.addProperty(EXISTING_ACT_CLAIM, existingActClaim);
+                    if (log.isDebugEnabled()) {
+                        log.debug("Found existing act claim chain: " + extractActorChain(existingActClaim));
+                    }
+                }
+
+                // A new actor token, when present, adds the next level to the delegation chain.
+                if (requestParams.containsKey(TokenExchangeConstants.ACTOR_TOKEN)) {
+                    validateActorTokenForDelegation(tokReqMsgCtx, requestParams, tenantDomain, existingActClaim);
                 }
             }
-
-            // A new actor token, when present, adds the next level to the delegation chain.
-            if (requestParams.containsKey(TokenExchangeConstants.ACTOR_TOKEN)) {
-                validateActorTokenForDelegation(tokReqMsgCtx, requestParams, tenantDomain, existingActClaim);
-            }
-            return true;
-
         } else {
-            // Generic JWT token exchange: neither impersonation nor delegation.
-            validateRequestedTokenType(requestedTokenType);
-
-            if (Constants.TokenExchangeConstants.JWT_TOKEN_TYPE.equals(subjectTokenType) || (Constants
-                    .TokenExchangeConstants.ACCESS_TOKEN_TYPE.equals(subjectTokenType)) && isJWT(requestParams
-                    .get(SUBJECT_TOKEN))) {
-                handleJWTSubjectToken(requestParams, tokReqMsgCtx, tenantDomain, requestedAudience);
-                if (tokReqMsgCtx.getAuthorizedUser() != null && !tokReqMsgCtx.getAuthorizedUser().isFederatedUser()) {
-                    validateLocalUser(tokReqMsgCtx, requestParams);
-                }
-            } else {
-                handleException(OAuth2ErrorCodes.INVALID_REQUEST,
-                        "Unsupported subject token type : " + subjectTokenType + " provided");
-            }
+            handleException(OAuth2ErrorCodes.INVALID_REQUEST,
+                    "Unsupported subject token type : " + subjectTokenType + " provided");
         }
         return true;
     }
 
+
     /**
-     * Checks if the token request is an impersonation request by inspecting the provided request parameters.
+     * Checks whether the request carries the subject and actor token parameters required for an
+     * impersonation or delegation token exchange.
      *
-     * @param requestParams A Map<String, String> containing the request parameters.
-     * @return true if the request is an impersonation request and false otherwise.
+     * @param requestParams request parameter map.
+     * @return true if all four subject/actor token parameters are present.
      */
-    private boolean isImpersonationRequest(Map<String, String> requestParams, JWTClaimsSet subjectClaimsSet) {
+    private boolean hasActorTokenParameters(Map<String, String> requestParams) {
 
-        // Check if all required parameters are present
-        if (!requestParams.containsKey(SUBJECT_TOKEN) ||
-                !requestParams.containsKey(TokenExchangeConstants.SUBJECT_TOKEN_TYPE) ||
-                !requestParams.containsKey(TokenExchangeConstants.ACTOR_TOKEN) ||
-                !requestParams.containsKey(TokenExchangeConstants.ACTOR_TOKEN_TYPE)) {
-            return false;
-        }
+        return requestParams.containsKey(SUBJECT_TOKEN)
+                && requestParams.containsKey(TokenExchangeConstants.SUBJECT_TOKEN_TYPE)
+                && requestParams.containsKey(TokenExchangeConstants.ACTOR_TOKEN)
+                && requestParams.containsKey(TokenExchangeConstants.ACTOR_TOKEN_TYPE);
+    }
 
-        // For impersonation, the subject token MUST have may_act claim
-        if (subjectClaimsSet == null) {
-            return false;
-        }
+    /**
+     * Checks if the token request is an impersonation request.
+     *
+     * @param subjectClaimsSet claims from the subject token.
+     * @return true if the subject token carries a may_act claim, false otherwise.
+     */
+    private boolean isImpersonationRequest(JWTClaimsSet subjectClaimsSet) {
+
+        // Impersonation requires a may_act claim in the subject token.
         return subjectClaimsSet.getClaim(MAY_ACT) != null;
     }
 
@@ -238,15 +264,7 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
      */
     private boolean isDelegationRequest(Map<String, String> requestParams, JWTClaimsSet subjectClaimsSet) {
 
-        if (!requestParams.containsKey(SUBJECT_TOKEN) ||
-                !requestParams.containsKey(TokenExchangeConstants.SUBJECT_TOKEN_TYPE)) {
-            return false;
-        }
-        if (subjectClaimsSet == null) {
-            return false;
-        }
-
-        // Subject token must not carry a may_act claim (that would be impersonation)
+        // Subject token must not carry a may_act claim.
         if (subjectClaimsSet.getClaim(MAY_ACT) != null) {
             return false;
         }
@@ -254,7 +272,6 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
         if (subjectClaimsSet.getClaim(ACT) != null) {
             return true;
         }
-
         // Otherwise, delegation requires a new actor token to be presented.
         return requestParams.containsKey(TokenExchangeConstants.ACTOR_TOKEN) &&
                 requestParams.containsKey(TokenExchangeConstants.ACTOR_TOKEN_TYPE);
@@ -331,29 +348,15 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
      * Checks if the subject token is signed by the Authorization Server (AS),
      * validates the token claims, and ensures it's intended for the correct audience and issuer.
      *
-     * @param tokReqMsgCtx  OauthTokenReqMessageContext
-     * @param requestParams A Map<String, String> containing the request parameters.
-     * @param tenantDomain  The tenant domain associated with the request.
+     * @param tokReqMsgCtx OauthTokenReqMessageContext
+     * @param tenantDomain The tenant domain associated with the request.
+     * @param signedJWT    The parsed subject token.
+     * @param claimsSet    The claims extracted from the subject token.
      * @throws IdentityOAuth2Exception If there's an error during token validation.
      */
-    private void validateSubjectToken(OAuthTokenReqMessageContext tokReqMsgCtx, Map<String, String> requestParams,
-                                      String tenantDomain)
+    private void validateSubjectToken(OAuthTokenReqMessageContext tokReqMsgCtx, String tenantDomain,
+                                      SignedJWT signedJWT, JWTClaimsSet claimsSet)
             throws IdentityOAuth2Exception {
-
-        // Retrieve the signed JWT object from the request parameters
-        SignedJWT signedJWT = getSignedJWT(requestParams.get(SUBJECT_TOKEN));
-        if (signedJWT == null) {
-            // If no valid subject token found, handle the exception
-            handleException(OAuth2ErrorCodes.INVALID_REQUEST,
-                    "No Valid subject token was found for " + TokenExchangeConstants.TOKEN_EXCHANGE_GRANT_TYPE);
-        }
-
-        // Extract claims from the JWT
-        JWTClaimsSet claimsSet = getClaimSet(signedJWT);
-        if (claimsSet == null) {
-            // If claim values are empty, handle the exception
-            handleException(OAuth2ErrorCodes.INVALID_REQUEST, "Claim values are empty in the given Subject Token");
-        }
 
         // Validate mandatory claims
         String subject = resolveSubject(claimsSet);
@@ -518,20 +521,12 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
                                                  Map<String, Object> existingActClaim)
             throws IdentityOAuth2Exception {
 
-        // Only JWT-based access tokens are accepted as actor tokens.
-        // Generic JWT type is excluded to prevent ID tokens from being used as actor tokens.
         String actorTokenType = requestParams.get(TokenExchangeConstants.ACTOR_TOKEN_TYPE);
-        if (!TokenExchangeConstants.ACCESS_TOKEN_TYPE.equals(actorTokenType)) {
+        if (!(TokenExchangeConstants.JWT_TOKEN_TYPE.equals(actorTokenType) || (TokenExchangeConstants
+                .ACCESS_TOKEN_TYPE.equals(actorTokenType)) && isJWT(requestParams
+                .get(TokenExchangeConstants.ACTOR_TOKEN)))) {
             handleException(OAuth2ErrorCodes.INVALID_REQUEST,
-                    "Unsupported actor token type: " + actorTokenType
-                            + ". Supported type: " + TokenExchangeConstants.ACCESS_TOKEN_TYPE);
-        }
-
-        // The access token must be a JWT.
-        if (!isJWT(requestParams.get(TokenExchangeConstants.ACTOR_TOKEN))) {
-            handleException(OAuth2ErrorCodes.INVALID_REQUEST,
-                    "Actor token type is " + TokenExchangeConstants.ACCESS_TOKEN_TYPE
-                            + " but the provided token is not a JWT. Only JWT-based access tokens are supported.");
+                    "Unsupported actor token type : " + actorTokenType + " provided");
         }
 
         // Retrieve the signed JWT object from the request parameters
@@ -552,7 +547,6 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
         // Validate mandatory claims
         String actorTokenSubject = resolveSubject(claimsSet);
         validateMandatoryClaims(claimsSet, actorTokenSubject);
-
 
         String jwtIssuer = claimsSet.getIssuer();
         IdentityProvider identityProvider = getIdentityProvider(tokReqMsgCtx, jwtIssuer, tenantDomain);
@@ -955,120 +949,106 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
         return tenantDomain;
     }
 
-    private void handleJWTSubjectToken(Map<String, String> requestParams, OAuthTokenReqMessageContext tokReqMsgCtx,
-                                       String tenantDomain, String requestedAudience) throws IdentityOAuth2Exception {
+    private void handleJWTSubjectToken(OAuthTokenReqMessageContext tokReqMsgCtx, String tenantDomain,
+                                       String requestedAudience, SignedJWT signedJWT, JWTClaimsSet claimsSet)
+            throws IdentityOAuth2Exception {
 
-        SignedJWT signedJWT;
         IdentityProvider identityProvider;
-        JWTClaimsSet claimsSet;
 
-        signedJWT = getSignedJWT(requestParams.get(SUBJECT_TOKEN));
-        if (signedJWT != null) {
-            claimsSet = getClaimSet(signedJWT);
-            if (claimsSet == null) {
-                handleException(OAuth2ErrorCodes.INVALID_REQUEST, "Claim values are empty in the given JSON Web Token");
-            }
+        String jwtIssuer = claimsSet.getIssuer();
+        String subject = resolveSubject(claimsSet);
+        List<String> audiences = claimsSet.getAudience();
+        Map<String, Object> customClaims = new HashMap<>(claimsSet.getClaims());
 
-            String jwtIssuer = claimsSet.getIssuer();
-            String subject = resolveSubject(claimsSet);
-            List<String> audiences = claimsSet.getAudience();
-            Map<String, Object> customClaims = new HashMap<>(claimsSet.getClaims());
+        tokReqMsgCtx.addProperty(Constants.EXPIRY_TIME, claimsSet.getExpirationTime());
 
-            tokReqMsgCtx.addProperty(Constants.EXPIRY_TIME, claimsSet.getExpirationTime());
+        validateMandatoryClaims(claimsSet, subject);
+        identityProvider = getIdentityProvider(tokReqMsgCtx, jwtIssuer, tenantDomain);
 
-            validateMandatoryClaims(claimsSet, subject);
-            identityProvider = getIdentityProvider(tokReqMsgCtx, jwtIssuer, tenantDomain);
+        boolean isLocalIdentityProvider = Constants.LOCAL_IDP_NAME.equals(identityProvider.
+                getIdentityProviderName());
 
-            boolean isLocalIdentityProvider = Constants.LOCAL_IDP_NAME.equals(identityProvider.
-                    getIdentityProviderName());
+        boolean isOrganization;
+        try {
+            isOrganization = OrganizationManagementUtil.isOrganization(tenantDomain);
+        } catch (OrganizationManagementException e) {
+            throw new IdentityOAuth2Exception("Error while checking whether the given tenant : " + tenantDomain +
+                    " is an organization", e);
+        }
 
-            boolean isOrganization;
-            try {
-                isOrganization = OrganizationManagementUtil.isOrganization(tenantDomain);
-            } catch (OrganizationManagementException e) {
-                throw new IdentityOAuth2Exception("Error while checking whether the given tenant : " + tenantDomain +
-                        " is an organization", e);
-            }
-
-            String issuerTenantDomain = tenantDomain;
-            /*
-             Handles the app to app token exchange in sub organization applications by getting the
-             issuer's tenant domain.
-            */
-            if (isOrganization && isLocalIdentityProvider) {
-                String clientId = claimsSet.getClaim(SUBJECT_TOKEN_CLIENT_ID) != null ?
-                        claimsSet.getClaim(SUBJECT_TOKEN_CLIENT_ID).toString() : null;
-                if (StringUtils.isNotEmpty(clientId)) {
-                    issuerTenantDomain = TokenExchangeUtils.resolveIssuerTenantDomain(jwtIssuer, clientId,
-                            tenantDomain);
-                    if (log.isDebugEnabled()) {
-                        log.debug("Resolved issuer tenant domain: " + issuerTenantDomain +
-                                " for client: " + clientId);
-                    }
-                } else {
-                    throw new IdentityOAuth2Exception("client_id claim is not found in the token to resolve " +
-                            "issuer tenant domain");
-                }
-            }
-
-            try {
-                if (validateSignature(signedJWT, identityProvider, issuerTenantDomain)) {
-                    log.debug("Signature/MAC validated successfully.");
-                } else {
-                    handleException(OAuth2ErrorCodes.INVALID_REQUEST, "Signature or Message Authentication "
-                            + "invalid");
-                }
-            } catch (JOSEException e) {
-                handleException(OAuth2ErrorCodes.INVALID_REQUEST, "Error when verifying signature", e);
-            }
-            checkJWTValidity(claimsSet);
-
-            RequestParameter[] params = tokReqMsgCtx.getOauth2AccessTokenReqDTO().getRequestParameters();
-            // Skip the issuer-in-audience check for locally issued tokens; the local issuer is already trusted.
-            if (!isLocalIdentityProvider) {
-                boolean audienceFound = validateAudience(audiences, identityProvider, requestedAudience, params,
+        String issuerTenantDomain = tenantDomain;
+        /*
+         Handles the app to app token exchange in sub organization applications by getting the
+         issuer's tenant domain.
+        */
+        if (isOrganization && isLocalIdentityProvider) {
+            String clientId = claimsSet.getClaim(SUBJECT_TOKEN_CLIENT_ID) != null ?
+                    claimsSet.getClaim(SUBJECT_TOKEN_CLIENT_ID).toString() : null;
+            if (StringUtils.isNotEmpty(clientId)) {
+                issuerTenantDomain = TokenExchangeUtils.resolveIssuerTenantDomain(jwtIssuer, clientId,
                         tenantDomain);
-                if (!audienceFound) {
-                    TokenExchangeUtils.handleClientException(Constants.TokenExchangeConstants.INVALID_TARGET,
-                            "Invalid audience values provided");
+                if (log.isDebugEnabled()) {
+                    log.debug("Resolved issuer tenant domain: " + issuerTenantDomain +
+                            " for client: " + clientId);
                 }
+            } else {
+                throw new IdentityOAuth2Exception("client_id claim is not found in the token to resolve " +
+                        "issuer tenant domain");
             }
+        }
 
-            try {
-                if (isOrganization && isLocalIdentityProvider) {
-                    /*
-                     At this point, signature validation was performed using the issuer organization's resident
-                     IDP to verify the subject token's authenticity. Now that the token is validated,
-                     the identity provider is switched to the sub organization's own resident IDP so
-                     that subsequent processing — custom claim validation, user resolution, and claim mapping —
-                     is governed by the sub organization's configuration rather than the issuer organization.
-                    */
-                    identityProvider = IdentityProviderManager.getInstance().getResidentIdP(tenantDomain);
-                }
-            } catch (IdentityProviderManagementException e) {
-                throw new IdentityOAuth2Exception(String.format(Constants.ERROR_GET_RESIDENT_IDP, tenantDomain), e);
+        try {
+            if (validateSignature(signedJWT, identityProvider, issuerTenantDomain)) {
+                log.debug("Signature/MAC validated successfully.");
+            } else {
+                handleException(OAuth2ErrorCodes.INVALID_REQUEST, "Signature or Message Authentication "
+                        + "invalid");
             }
+        } catch (JOSEException e) {
+            handleException(OAuth2ErrorCodes.INVALID_REQUEST, "Error when verifying signature", e);
+        }
+        checkJWTValidity(claimsSet);
 
-            boolean customClaimsValidated = validateCustomClaims(claimsSet.getClaims(), identityProvider, params);
-            if (!customClaimsValidated) {
-                handleException(OAuth2ErrorCodes.INVALID_REQUEST, "Custom Claims in the JWT were invalid");
+        RequestParameter[] params = tokReqMsgCtx.getOauth2AccessTokenReqDTO().getRequestParameters();
+        // Skip the issuer-in-audience check for locally issued tokens; the local issuer is already trusted.
+        if (!isLocalIdentityProvider) {
+            audienceFound = validateAudience(audiences, identityProvider, requestedAudience, params, tenantDomain);
+            if (!audienceFound) {
+                TokenExchangeUtils.handleClientException(Constants.TokenExchangeConstants.INVALID_TARGET,
+                        "Invalid audience values provided");
             }
+        }
 
-            TokenExchangeUtils.setAuthorizedUser(tokReqMsgCtx, identityProvider, subject, claimsSet);
-            if (log.isDebugEnabled()) {
-                log.debug("Subject(sub) found in JWT: " + subject + " and set as the Authorized User.");
+        try {
+            if (isOrganization && isLocalIdentityProvider) {
+                /*
+                 At this point, signature validation was performed using the issuer organization's resident
+                 IDP to verify the subject token's authenticity. Now that the token is validated,
+                 the identity provider is switched to the sub organization's own resident IDP so
+                 that subsequent processing — custom claim validation, user resolution, and claim mapping —
+                 is governed by the sub organization's configuration rather than the issuer organization.
+                */
+                identityProvider = IdentityProviderManager.getInstance().getResidentIdP(tenantDomain);
             }
+        } catch (IdentityProviderManagementException e) {
+            throw new IdentityOAuth2Exception(String.format(Constants.ERROR_GET_RESIDENT_IDP, tenantDomain), e);
+        }
 
-            tokReqMsgCtx.setScope(tokReqMsgCtx.getOauth2AccessTokenReqDTO().getScope());
-            enrichCustomClaims(customClaims, identityProvider, params);
-            log.debug("Subject JWT Token was validated successfully");
-            if (OAuth2Util.isOIDCAuthzRequest(tokReqMsgCtx.getScope())) {
-                handleCustomClaims(tokReqMsgCtx, customClaims, identityProvider, tenantDomain);
-            }
+        boolean customClaimsValidated = validateCustomClaims(claimsSet.getClaims(), identityProvider, params);
+        if (!customClaimsValidated) {
+            handleException(OAuth2ErrorCodes.INVALID_REQUEST, "Custom Claims in the JWT were invalid");
+        }
 
-        } else {
-            handleException(OAuth2ErrorCodes.INVALID_REQUEST, "No Valid subject token was found for "
-                    + Constants.TokenExchangeConstants.TOKEN_EXCHANGE_GRANT_TYPE);
+        TokenExchangeUtils.setAuthorizedUser(tokReqMsgCtx, identityProvider, subject, claimsSet);
+        if (log.isDebugEnabled()) {
+            log.debug("Subject(sub) found in JWT: " + subject + " and set as the Authorized User.");
+        }
+
+        tokReqMsgCtx.setScope(tokReqMsgCtx.getOauth2AccessTokenReqDTO().getScope());
+        enrichCustomClaims(customClaims, identityProvider, params);
+        log.debug("Subject JWT Token was validated successfully");
+        if (OAuth2Util.isOIDCAuthzRequest(tokReqMsgCtx.getScope())) {
+            handleCustomClaims(tokReqMsgCtx, customClaims, identityProvider, tenantDomain);
         }
     }
 

--- a/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/internal/TokenExchangeComponentServiceHolder.java
+++ b/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/internal/TokenExchangeComponentServiceHolder.java
@@ -19,6 +19,8 @@ package org.wso2.carbon.identity.oauth2.grant.token.exchange.internal;
 
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
+import org.wso2.carbon.identity.handler.event.account.lock.service.AccountDisableService;
+import org.wso2.carbon.identity.handler.event.account.lock.service.AccountLockService;
 import org.wso2.carbon.identity.oauth2.config.services.OAuth2OIDCConfigOrgUsageScopeMgtService;
 import org.wso2.carbon.identity.user.profile.mgt.association.federation.FederatedAssociationManager;
 import org.wso2.carbon.user.core.listener.UserOperationEventListener;
@@ -38,6 +40,8 @@ public class TokenExchangeComponentServiceHolder {
     private FederatedAssociationManager federatedAssociationManager;
     private ClaimMetadataManagementService claimMetadataManagementService;
     private OAuth2OIDCConfigOrgUsageScopeMgtService oAuth2OIDCConfigOrgUsageScopeMgtService;
+    private AccountLockService accountLockService;
+    private AccountDisableService accountDisableService;
 
     public static TokenExchangeComponentServiceHolder getInstance() {
         return INSTANCE;
@@ -113,5 +117,25 @@ public class TokenExchangeComponentServiceHolder {
     public OAuth2OIDCConfigOrgUsageScopeMgtService getOAuth2OIDCConfigOrgUsageScopeMgtService() {
 
         return this.oAuth2OIDCConfigOrgUsageScopeMgtService;
+    }
+
+    public AccountLockService getAccountLockService() {
+
+        return accountLockService;
+    }
+
+    public void setAccountLockService(AccountLockService accountLockService) {
+
+        this.accountLockService = accountLockService;
+    }
+
+    public AccountDisableService getAccountDisableService() {
+
+        return accountDisableService;
+    }
+
+    public void setAccountDisableService(AccountDisableService accountDisableService) {
+
+        this.accountDisableService = accountDisableService;
     }
 }

--- a/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/internal/TokenExchangeServiceComponent.java
+++ b/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/internal/TokenExchangeServiceComponent.java
@@ -27,6 +27,8 @@ import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
+import org.wso2.carbon.identity.handler.event.account.lock.service.AccountDisableService;
+import org.wso2.carbon.identity.handler.event.account.lock.service.AccountLockService;
 import org.wso2.carbon.identity.oauth2.config.services.OAuth2OIDCConfigOrgUsageScopeMgtService;
 import org.wso2.carbon.identity.user.profile.mgt.association.federation.FederatedAssociationManager;
 import org.wso2.carbon.user.core.listener.UserOperationEventListener;
@@ -199,5 +201,39 @@ public class TokenExchangeServiceComponent {
                                                                         oAuth2OIDCConfigOrgUsageScopeMgtService) {
 
         TokenExchangeComponentServiceHolder.getInstance().setOAuth2OIDCConfigOrgUsageScopeMgtService(null);
+    }
+
+    @Reference(
+            name = "org.wso2.carbon.identity.handler.event.account.lock.service.AccountLockService",
+            service = AccountLockService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetAccountLockService"
+    )
+    protected void setAccountLockService(AccountLockService accountLockService) {
+
+        TokenExchangeComponentServiceHolder.getInstance().setAccountLockService(accountLockService);
+    }
+
+    protected void unsetAccountLockService(AccountLockService accountLockService) {
+
+        TokenExchangeComponentServiceHolder.getInstance().setAccountLockService(null);
+    }
+
+    @Reference(
+            name = "org.wso2.carbon.identity.handler.event.account.lock.service.AccountDisableService",
+            service = AccountDisableService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetAccountDisableService"
+    )
+    protected void setAccountDisableService(AccountDisableService accountDisableService) {
+
+        TokenExchangeComponentServiceHolder.getInstance().setAccountDisableService(accountDisableService);
+    }
+
+    protected void unsetAccountDisableService(AccountDisableService accountDisableService) {
+
+        TokenExchangeComponentServiceHolder.getInstance().setAccountDisableService(null);
     }
 }

--- a/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/utils/TokenExchangeUtils.java
+++ b/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/utils/TokenExchangeUtils.java
@@ -694,7 +694,7 @@ public class TokenExchangeUtils {
     }
 
     /**
-     * Method to create an association between the provider local user and the identity provider
+     * Method to create an association between the provider local user and the identity provider.
      * @param user    Local user
      * @param idp   Identity provider
      * @param subject  Subject identifier

--- a/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/utils/TokenExchangeUtils.java
+++ b/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/utils/TokenExchangeUtils.java
@@ -33,6 +33,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.json.JSONObject;
 import org.wso2.carbon.CarbonConstants;
+import org.wso2.carbon.identity.application.authentication.framework.exception.FrameworkException;
 import org.wso2.carbon.identity.application.authentication.framework.exception.UserIdNotFoundException;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
@@ -61,6 +62,8 @@ import org.wso2.carbon.identity.core.util.IdentityConfigParser;
 import org.wso2.carbon.identity.core.util.IdentityCoreConstants;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.handler.event.account.lock.exception.AccountDisableServiceException;
+import org.wso2.carbon.identity.handler.event.account.lock.exception.AccountLockServiceException;
 import org.wso2.carbon.identity.oauth.common.OAuth2ErrorCodes;
 import org.wso2.carbon.identity.oauth.common.exception.InvalidOAuthClientException;
 import org.wso2.carbon.identity.oauth.dao.OAuthAppDO;
@@ -114,6 +117,7 @@ import java.util.Optional;
 
 import javax.xml.namespace.QName;
 
+import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.ResidentIdpPropertyName.ACCOUNT_DISABLE_HANDLER_ENABLE_PROPERTY;
 import static org.wso2.carbon.identity.oauth2.grant.token.exchange.Constants.DEFAULT_IDP_NAME;
 import static org.wso2.carbon.identity.oauth2.grant.token.exchange.Constants.REGISTERED_CLAIMS;
 import static org.wso2.carbon.utils.CarbonUtils.isLegacyAuditLogsDisabled;
@@ -1407,5 +1411,61 @@ public class TokenExchangeUtils {
         }
         // At this point 'verifier' will never be null;
         return signedJWT.verify(verifier);
+    }
+
+    /**
+     * Check whether the given user account is locked.
+     *
+     * @param userName  Username of the user.
+     * @param tenantDomain  Tenant domain of the user.
+     * @param userStoreDomain  User store domain of the user.
+     * @return  true if the account is locked or the given parameters are incomplete.
+     * @throws IdentityOAuth2Exception  Identity OAuth2 Exception.
+     */
+    public static boolean isUserAccountLocked(String userName, String tenantDomain, String userStoreDomain)
+            throws IdentityOAuth2Exception {
+
+        if (userName != null && tenantDomain != null && userStoreDomain != null) {
+            try {
+                return TokenExchangeComponentServiceHolder.getInstance().getAccountLockService()
+                        .isAccountLocked(userName, tenantDomain, userStoreDomain);
+            } catch (AccountLockServiceException e) {
+                throw new IdentityOAuth2Exception("Error while checking the account lock status of the user.", e);
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Check whether the given user account is disabled.
+     *
+     * @param userName  Username of the user.
+     * @param tenantDomain  Tenant domain of the user.
+     * @param userStoreDomain  User store domain of the user.
+     * @return  true if the account is disabled or the given parameters are incomplete.
+     * @throws IdentityOAuth2Exception  Identity OAuth2 Exception.
+     */
+    public static boolean isUserAccountDisabled(String userName, String tenantDomain, String userStoreDomain)
+            throws IdentityOAuth2Exception {
+
+        if (userName != null && tenantDomain != null && userStoreDomain != null) {
+            try {
+                if (!isAccountDisablingEnabled(tenantDomain)) {
+                    return false;
+                }
+                return TokenExchangeComponentServiceHolder.getInstance().getAccountDisableService()
+                        .isAccountDisabled(userName, tenantDomain, userStoreDomain);
+            } catch (IllegalArgumentException | AccountDisableServiceException | FrameworkException e) {
+                throw new IdentityOAuth2Exception("Error while checking the account disable status of the user.", e);
+            }
+        }
+        return true;
+    }
+
+    private static boolean isAccountDisablingEnabled(String tenantDomain) throws FrameworkException {
+
+        Property accountDisableConfigProperty = FrameworkUtils.getResidentIdpConfiguration(
+                ACCOUNT_DISABLE_HANDLER_ENABLE_PROPERTY, tenantDomain);
+        return accountDisableConfigProperty != null && Boolean.parseBoolean(accountDisableConfigProperty.getValue());
     }
 }

--- a/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/test/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandlerTest.java
+++ b/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/test/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandlerTest.java
@@ -299,7 +299,7 @@ public class TokenExchangeGrantHandlerTest {
         return new Object[][]{
                 {true, false, ISSUER, CLIENT_ID, IMPERSONATOR_ID, false, ISSUER, IMPERSONATOR_ID},
                 {true, true, ISSUER, CLIENT_ID, IMPERSONATOR_ID, false, ISSUER, IMPERSONATOR_ID},
-                {false, true, "NegativeIssuer", CLIENT_ID, IMPERSONATOR_ID, false, ISSUER, IMPERSONATOR_ID},
+                {false, false, "NegativeIssuer", CLIENT_ID, IMPERSONATOR_ID, false, ISSUER, IMPERSONATOR_ID},
                 {true, true, ISSUER, "NegativeClient", IMPERSONATOR_ID, false, ISSUER, IMPERSONATOR_ID},
                 {false, false, ISSUER, CLIENT_ID, IMPERSONATOR_ID, true, ISSUER, IMPERSONATOR_ID},
                 {false, false, ISSUER, CLIENT_ID, IMPERSONATOR_ID, false, "NegativeIssuer", IMPERSONATOR_ID},
@@ -609,6 +609,7 @@ public class TokenExchangeGrantHandlerTest {
         tokenExchangeUtils.when(() -> TokenExchangeUtils.validateSignature(actorToken, idp, "carbon.super"))
                 .thenReturn(true);
         oAuth2Util.when(() -> OAuth2Util.isJWT(actorToken.serialize())).thenReturn(true);
+        oAuth2Util.when(() -> OAuth2Util.isJWT(subjectToken.serialize())).thenReturn(true);
         AbstractUserStoreManager mockUserStoreManager = Mockito.mock(AbstractUserStoreManager.class);
         try {
             Mockito.doReturn("actorUser").when(mockUserStoreManager).getUserNameFromUserID(ACTOR_SUBJECT_ID);

--- a/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/test/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandlerTest.java
+++ b/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/test/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandlerTest.java
@@ -36,6 +36,7 @@ import org.wso2.carbon.identity.application.authentication.framework.model.Authe
 import org.wso2.carbon.identity.application.common.model.IdentityProvider;
 import org.wso2.carbon.identity.application.common.model.IdentityProviderProperty;
 import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
+import org.wso2.carbon.identity.oauth2.IdentityOAuth2ClientException;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2AccessTokenReqDTO;
 import org.wso2.carbon.identity.oauth2.grant.token.exchange.utils.TokenExchangeUtils;

--- a/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/test/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandlerTest.java
+++ b/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/test/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandlerTest.java
@@ -60,9 +60,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
-import static org.wso2.carbon.identity.oauth.common.OAuthConstants.ACTOR_AZP;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.ACTOR_SUBJECT;
-import static org.wso2.carbon.identity.oauth.common.OAuthConstants.DELEGATING_ACTOR;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.EXISTING_ACT_CLAIM;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.IMPERSONATED_SUBJECT;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.IMPERSONATING_ACTOR;
@@ -387,8 +385,6 @@ public class TokenExchangeGrantHandlerTest {
         Assert.assertTrue(isValid);
         Assert.assertTrue(ctx.isDelegationRequest());
         Assert.assertEquals(ctx.getProperty(ACTOR_SUBJECT), ACTOR_SUBJECT_ID);
-        Assert.assertEquals(ctx.getProperty(ACTOR_AZP), ACTOR_CLIENT_ID);
-        Assert.assertEquals(ctx.getProperty(DELEGATING_ACTOR), ACTOR_SUBJECT_ID);
     }
 
     @Test
@@ -425,9 +421,10 @@ public class TokenExchangeGrantHandlerTest {
 
         Assert.assertTrue(isValid);
         Assert.assertTrue(ctx.isDelegationRequest());
-        Assert.assertEquals(ctx.getProperty(DELEGATING_ACTOR), CLIENT_ID);
-        Assert.assertEquals(ctx.getProperty(ACTOR_SUBJECT), ACTOR_SUBJECT_ID);
-//        Assert.assertEquals(ctx.getProperty(ACTOR_AZP), CLIENT_ID);
+        // No new actor token in a re-exchange: no new delegation level is added...
+        Assert.assertNull(ctx.getProperty(ACTOR_SUBJECT));
+        // ...and the existing act claim is preserved so it can be carried forward unchanged.
+        Assert.assertNotNull(ctx.getProperty(EXISTING_ACT_CLAIM));
     }
 
     @Test

--- a/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/test/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandlerTest.java
+++ b/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/test/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandlerTest.java
@@ -66,7 +66,6 @@ import static org.wso2.carbon.identity.oauth.common.OAuthConstants.DELEGATING_AC
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.EXISTING_ACT_CLAIM;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.IMPERSONATED_SUBJECT;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.IMPERSONATING_ACTOR;
-import static org.wso2.carbon.identity.oauth.common.OAuthConstants.IS_DELEGATION_REQUEST;
 
 /**
  * Unit tests for {@link TokenExchangeGrantHandler}.
@@ -386,21 +385,21 @@ public class TokenExchangeGrantHandlerTest {
         boolean isValid = tokenExchangeGrantHandler.validateGrant(ctx);
 
         Assert.assertTrue(isValid);
-        Assert.assertEquals(ctx.getProperty(IS_DELEGATION_REQUEST), true);
+        Assert.assertTrue(ctx.isDelegationRequest());
         Assert.assertEquals(ctx.getProperty(ACTOR_SUBJECT), ACTOR_SUBJECT_ID);
         Assert.assertEquals(ctx.getProperty(ACTOR_AZP), ACTOR_CLIENT_ID);
         Assert.assertEquals(ctx.getProperty(DELEGATING_ACTOR), ACTOR_SUBJECT_ID);
     }
 
     @Test
-    public void testValidateSelfDelegation() throws Exception {
+    public void testValidateDelegationReExchange() throws Exception {
 
         KeyPairGenerator keyGenerator = KeyPairGenerator.getInstance("RSA");
         KeyPair keyPair = keyGenerator.generateKeyPair();
         Instant now = Instant.now();
         Map<String, Object> existingAct = new HashMap<>();
         existingAct.put("sub", ACTOR_SUBJECT_ID);
-        JWTClaimsSet selfDelegationClaims = new JWTClaimsSet.Builder()
+        JWTClaimsSet delegationReExchangeClaims = new JWTClaimsSet.Builder()
                 .issuer(ISSUER)
                 .subject(IMPERSONATED_SUBJECT_ID)
                 .audience(CLIENT_ID)
@@ -411,21 +410,21 @@ public class TokenExchangeGrantHandlerTest {
                 .claim("scope", "default")
                 .claim("act", existingAct)
                 .build();
-        SignedJWT subjectToken = signJWT(keyPair, selfDelegationClaims);
+        SignedJWT subjectToken = signJWT(keyPair, delegationReExchangeClaims);
 
         OAuth2AccessTokenReqDTO reqDTO = new OAuth2AccessTokenReqDTO();
         reqDTO.setClientId(CLIENT_ID);
         reqDTO.setGrantType(Constants.TokenExchangeConstants.TOKEN_EXCHANGE_GRANT_TYPE);
         reqDTO.setTenantDomain("carbon.super");
         reqDTO.setScope(new String[]{"default"});
-        reqDTO.setRequestParameters(buildSelfDelegationRequestParams(subjectToken));
+        reqDTO.setRequestParameters(buildDelegationReExchangeRequestParams(subjectToken));
         OAuthTokenReqMessageContext ctx = new OAuthTokenReqMessageContext(reqDTO);
 
-        prepareTokenUtilsForSelfDelegation(subjectToken);
+        prepareTokenUtilsForDelegationReExchange(subjectToken);
         boolean isValid = tokenExchangeGrantHandler.validateGrant(ctx);
 
         Assert.assertTrue(isValid);
-        Assert.assertEquals(ctx.getProperty(IS_DELEGATION_REQUEST), true);
+        Assert.assertTrue(ctx.isDelegationRequest());
         Assert.assertEquals(ctx.getProperty(DELEGATING_ACTOR), CLIENT_ID);
         Assert.assertEquals(ctx.getProperty(ACTOR_SUBJECT), ACTOR_SUBJECT_ID);
 //        Assert.assertEquals(ctx.getProperty(ACTOR_AZP), CLIENT_ID);
@@ -465,7 +464,7 @@ public class TokenExchangeGrantHandlerTest {
         boolean isValid = tokenExchangeGrantHandler.validateGrant(ctx);
 
         Assert.assertTrue(isValid);
-        Assert.assertEquals(ctx.getProperty(IS_DELEGATION_REQUEST), true);
+        Assert.assertTrue(ctx.isDelegationRequest());
         Assert.assertNotNull(ctx.getProperty(EXISTING_ACT_CLAIM), "Existing act claim must be preserved on context");
     }
 
@@ -586,7 +585,7 @@ public class TokenExchangeGrantHandlerTest {
         };
     }
 
-    private RequestParameter[] buildSelfDelegationRequestParams(SignedJWT subjectToken) {
+    private RequestParameter[] buildDelegationReExchangeRequestParams(SignedJWT subjectToken) {
 
         return new RequestParameter[]{
                 new RequestParameter(Constants.TokenExchangeConstants.SUBJECT_TOKEN_TYPE,
@@ -626,7 +625,7 @@ public class TokenExchangeGrantHandlerTest {
                 .thenAnswer(invocation -> null);
     }
 
-    private void prepareTokenUtilsForSelfDelegation(SignedJWT subjectToken) throws ParseException {
+    private void prepareTokenUtilsForDelegationReExchange(SignedJWT subjectToken) throws ParseException {
 
         tokenExchangeUtils.when(() -> TokenExchangeUtils.getSignedJWT(subjectToken.serialize()))
                 .thenReturn(subjectToken);

--- a/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/test/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandlerTest.java
+++ b/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/test/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandlerTest.java
@@ -42,6 +42,7 @@ import org.wso2.carbon.identity.oauth2.model.RequestParameter;
 import org.wso2.carbon.identity.oauth2.token.OAuthTokenReqMessageContext;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 import org.wso2.carbon.identity.organization.management.service.util.OrganizationManagementUtil;
+import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
 
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
@@ -52,15 +53,24 @@ import java.time.Instant;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.ACTOR_AZP;
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.ACTOR_SUBJECT;
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.DELEGATING_ACTOR;
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.EXISTING_ACT_CLAIM;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.IMPERSONATED_SUBJECT;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.IMPERSONATING_ACTOR;
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.IS_DELEGATION_REQUEST;
 
+/**
+ * Unit tests for {@link TokenExchangeGrantHandler}.
+ */
 public class TokenExchangeGrantHandlerTest {
 
     private SignedJWT signedJWT;
@@ -76,6 +86,9 @@ public class TokenExchangeGrantHandlerTest {
     private static final String IMPERSONATED_SUBJECT_ID = "d9982d93-4e73-4565-b7ac-3605e8d05f80";
     private static final String ISSUER = "https://localhost:9443/oauth2/token";
     private static final String CLIENT_ID = "7N7vQHZbJtPnzegtGXJvvwDL4wca0";
+    private static final String ACTOR_CLIENT_ID = "actor-app-client-id";
+    private static final String ACTOR_SUBJECT_ID = "f3e12a77-9c4b-4d82-ae61-8b3c24f19e05";
+
 
 
     @BeforeTest
@@ -288,10 +301,9 @@ public class TokenExchangeGrantHandlerTest {
 
         return new Object[][]{
                 {true, false, ISSUER, CLIENT_ID, IMPERSONATOR_ID, false, ISSUER, IMPERSONATOR_ID},
-                {false, true, ISSUER, CLIENT_ID, IMPERSONATOR_ID, false, ISSUER, IMPERSONATOR_ID},
+                {true, true, ISSUER, CLIENT_ID, IMPERSONATOR_ID, false, ISSUER, IMPERSONATOR_ID},
                 {false, true, "NegativeIssuer", CLIENT_ID, IMPERSONATOR_ID, false, ISSUER, IMPERSONATOR_ID},
-                {false, true, ISSUER, "NegativeClient", IMPERSONATOR_ID, false, ISSUER, IMPERSONATOR_ID},
-                {false, true, ISSUER, CLIENT_ID, IMPERSONATOR_ID, false, ISSUER, IMPERSONATOR_ID},
+                {true, true, ISSUER, "NegativeClient", IMPERSONATOR_ID, false, ISSUER, IMPERSONATOR_ID},
                 {false, false, ISSUER, CLIENT_ID, IMPERSONATOR_ID, true, ISSUER, IMPERSONATOR_ID},
                 {false, false, ISSUER, CLIENT_ID, IMPERSONATOR_ID, false, "NegativeIssuer", IMPERSONATOR_ID},
                 {false, false, ISSUER, CLIENT_ID, IMPERSONATOR_ID, false, ISSUER, "NegativeImpersonator"}
@@ -355,6 +367,277 @@ public class TokenExchangeGrantHandlerTest {
                 .thenReturn(true);
     }
 
+
+    @Test
+    public void testValidateDelegationWithActorToken() throws Exception {
+
+        SignedJWT subjectToken = buildDelegationSubjectToken();
+        SignedJWT actorToken = buildActorTokenForDelegation();
+
+        OAuth2AccessTokenReqDTO reqDTO = new OAuth2AccessTokenReqDTO();
+        reqDTO.setClientId(CLIENT_ID);
+        reqDTO.setGrantType(Constants.TokenExchangeConstants.TOKEN_EXCHANGE_GRANT_TYPE);
+        reqDTO.setTenantDomain("carbon.super");
+        reqDTO.setScope(new String[]{"default"});
+        reqDTO.setRequestParameters(buildDelegationRequestParams(subjectToken, actorToken));
+        OAuthTokenReqMessageContext ctx = new OAuthTokenReqMessageContext(reqDTO);
+
+        prepareTokenUtilsForDelegation(subjectToken, actorToken);
+        boolean isValid = tokenExchangeGrantHandler.validateGrant(ctx);
+
+        Assert.assertTrue(isValid);
+        Assert.assertEquals(ctx.getProperty(IS_DELEGATION_REQUEST), true);
+        Assert.assertEquals(ctx.getProperty(ACTOR_SUBJECT), ACTOR_SUBJECT_ID);
+        Assert.assertEquals(ctx.getProperty(ACTOR_AZP), ACTOR_CLIENT_ID);
+        Assert.assertEquals(ctx.getProperty(DELEGATING_ACTOR), ACTOR_SUBJECT_ID);
+    }
+
+    @Test
+    public void testValidateSelfDelegation() throws Exception {
+
+        KeyPairGenerator keyGenerator = KeyPairGenerator.getInstance("RSA");
+        KeyPair keyPair = keyGenerator.generateKeyPair();
+        Instant now = Instant.now();
+        Map<String, Object> existingAct = new HashMap<>();
+        existingAct.put("sub", ACTOR_SUBJECT_ID);
+        JWTClaimsSet selfDelegationClaims = new JWTClaimsSet.Builder()
+                .issuer(ISSUER)
+                .subject(IMPERSONATED_SUBJECT_ID)
+                .audience(CLIENT_ID)
+                .issueTime(Date.from(now))
+                .expirationTime(Date.from(Instant.ofEpochSecond(now.getEpochSecond() + 36000)))
+                .notBeforeTime(Date.from(now))
+                .claim("azp", CLIENT_ID)
+                .claim("scope", "default")
+                .claim("act", existingAct)
+                .build();
+        SignedJWT subjectToken = signJWT(keyPair, selfDelegationClaims);
+
+        OAuth2AccessTokenReqDTO reqDTO = new OAuth2AccessTokenReqDTO();
+        reqDTO.setClientId(CLIENT_ID);
+        reqDTO.setGrantType(Constants.TokenExchangeConstants.TOKEN_EXCHANGE_GRANT_TYPE);
+        reqDTO.setTenantDomain("carbon.super");
+        reqDTO.setScope(new String[]{"default"});
+        reqDTO.setRequestParameters(buildSelfDelegationRequestParams(subjectToken));
+        OAuthTokenReqMessageContext ctx = new OAuthTokenReqMessageContext(reqDTO);
+
+        prepareTokenUtilsForSelfDelegation(subjectToken);
+        boolean isValid = tokenExchangeGrantHandler.validateGrant(ctx);
+
+        Assert.assertTrue(isValid);
+        Assert.assertEquals(ctx.getProperty(IS_DELEGATION_REQUEST), true);
+        Assert.assertEquals(ctx.getProperty(DELEGATING_ACTOR), CLIENT_ID);
+        Assert.assertEquals(ctx.getProperty(ACTOR_SUBJECT), ACTOR_SUBJECT_ID);
+//        Assert.assertEquals(ctx.getProperty(ACTOR_AZP), CLIENT_ID);
+    }
+
+    @Test
+    public void testValidateDelegationPreservesExistingActClaim() throws Exception {
+
+        KeyPairGenerator keyGenerator = KeyPairGenerator.getInstance("RSA");
+        KeyPair keyPair = keyGenerator.generateKeyPair();
+        Instant now = Instant.now();
+        Map<String, Object> existingAct = new HashMap<>();
+        existingAct.put("sub", "previous-actor-sub");
+        JWTClaimsSet claims = new JWTClaimsSet.Builder()
+                .issuer(ISSUER)
+                .subject(IMPERSONATED_SUBJECT_ID)
+                .audience(CLIENT_ID)
+                .issueTime(Date.from(now))
+                .expirationTime(Date.from(Instant.ofEpochSecond(now.getEpochSecond() + 36000)))
+                .notBeforeTime(Date.from(now))
+                .claim("azp", ACTOR_CLIENT_ID)
+                .claim("scope", "default")
+                .claim("act", existingAct)
+                .build();
+        SignedJWT subjectToken = signJWT(keyPair, claims);
+        SignedJWT actorToken = buildActorTokenForDelegation();
+
+        OAuth2AccessTokenReqDTO reqDTO = new OAuth2AccessTokenReqDTO();
+        reqDTO.setClientId(CLIENT_ID);
+        reqDTO.setGrantType(Constants.TokenExchangeConstants.TOKEN_EXCHANGE_GRANT_TYPE);
+        reqDTO.setTenantDomain("carbon.super");
+        reqDTO.setScope(new String[]{"default"});
+        reqDTO.setRequestParameters(buildDelegationRequestParams(subjectToken, actorToken));
+        OAuthTokenReqMessageContext ctx = new OAuthTokenReqMessageContext(reqDTO);
+
+        prepareTokenUtilsForDelegation(subjectToken, actorToken);
+        boolean isValid = tokenExchangeGrantHandler.validateGrant(ctx);
+
+        Assert.assertTrue(isValid);
+        Assert.assertEquals(ctx.getProperty(IS_DELEGATION_REQUEST), true);
+        Assert.assertNotNull(ctx.getProperty(EXISTING_ACT_CLAIM), "Existing act claim must be preserved on context");
+    }
+
+    @DataProvider(name = "delegationNegativeTestData")
+    public Object[][] delegationNegativeTestData() {
+
+        return new Object[][]{
+                {true, false},
+                {false, true},
+        };
+    }
+
+    @Test(dataProvider = "delegationNegativeTestData", expectedExceptions = IdentityOAuth2Exception.class)
+    public void testValidateDelegationNegative(boolean subjectTokenWithoutExpiry,
+                                               boolean actorTokenWithoutExpiry) throws Exception {
+
+        SignedJWT subjectToken = subjectTokenWithoutExpiry
+                ? buildDelegationSubjectTokenWithoutExpiry()
+                : buildDelegationSubjectToken();
+        SignedJWT actorToken = actorTokenWithoutExpiry
+                ? buildActorTokenForDelegationWithoutExpiry()
+                : buildActorTokenForDelegation();
+
+        OAuth2AccessTokenReqDTO reqDTO = new OAuth2AccessTokenReqDTO();
+        reqDTO.setClientId(CLIENT_ID);
+        reqDTO.setGrantType(Constants.TokenExchangeConstants.TOKEN_EXCHANGE_GRANT_TYPE);
+        reqDTO.setTenantDomain("carbon.super");
+        reqDTO.setScope(new String[]{"default"});
+        reqDTO.setRequestParameters(buildDelegationRequestParams(subjectToken, actorToken));
+        OAuthTokenReqMessageContext ctx = new OAuthTokenReqMessageContext(reqDTO);
+
+        prepareTokenUtilsForDelegation(subjectToken, actorToken);
+        tokenExchangeGrantHandler.validateGrant(ctx);
+    }
+
+    private SignedJWT signJWT(KeyPair keyPair, JWTClaimsSet claims) throws JOSEException {
+
+        JWSHeader header = new JWSHeader.Builder(JWSAlgorithm.RS256).keyID("KID").build();
+        SignedJWT signedJWT = new SignedJWT(header, claims);
+        signedJWT.sign(new RSASSASigner((RSAPrivateKey) keyPair.getPrivate()));
+        return signedJWT;
+    }
+
+    private SignedJWT buildDelegationSubjectToken() throws NoSuchAlgorithmException, JOSEException {
+
+        KeyPairGenerator keyGenerator = KeyPairGenerator.getInstance("RSA");
+        KeyPair keyPair = keyGenerator.generateKeyPair();
+        Instant now = Instant.now();
+        JWTClaimsSet claims = new JWTClaimsSet.Builder()
+                .issuer(ISSUER)
+                .subject(IMPERSONATED_SUBJECT_ID)
+                .audience(CLIENT_ID)
+                .issueTime(Date.from(now))
+                .expirationTime(Date.from(Instant.ofEpochSecond(now.getEpochSecond() + 36000)))
+                .notBeforeTime(Date.from(now))
+                .claim("azp", ACTOR_CLIENT_ID)
+                .claim("scope", "default")
+                .build();
+        return signJWT(keyPair, claims);
+    }
+
+    private SignedJWT buildDelegationSubjectTokenWithoutExpiry() throws NoSuchAlgorithmException, JOSEException {
+
+        KeyPairGenerator keyGenerator = KeyPairGenerator.getInstance("RSA");
+        KeyPair keyPair = keyGenerator.generateKeyPair();
+        JWTClaimsSet claims = new JWTClaimsSet.Builder()
+                .issuer(ISSUER)
+                .subject(IMPERSONATED_SUBJECT_ID)
+                .audience(CLIENT_ID)
+                .claim("azp", ACTOR_CLIENT_ID)
+                .claim("scope", "default")
+                .build();
+        return signJWT(keyPair, claims);
+    }
+
+    private SignedJWT buildActorTokenForDelegation() throws NoSuchAlgorithmException, JOSEException {
+
+        KeyPairGenerator keyGenerator = KeyPairGenerator.getInstance("RSA");
+        KeyPair keyPair = keyGenerator.generateKeyPair();
+        Instant now = Instant.now();
+        JWTClaimsSet claims = new JWTClaimsSet.Builder()
+                .issuer(ISSUER)
+                .subject(ACTOR_SUBJECT_ID)
+                .audience(CLIENT_ID)
+                .issueTime(Date.from(now))
+                .expirationTime(Date.from(Instant.ofEpochSecond(now.getEpochSecond() + 36000)))
+                .notBeforeTime(Date.from(now))
+                .claim("azp", ACTOR_CLIENT_ID)
+                .build();
+        return signJWT(keyPair, claims);
+    }
+
+    private SignedJWT buildActorTokenForDelegationWithoutExpiry() throws NoSuchAlgorithmException, JOSEException {
+
+        KeyPairGenerator keyGenerator = KeyPairGenerator.getInstance("RSA");
+        KeyPair keyPair = keyGenerator.generateKeyPair();
+        JWTClaimsSet claims = new JWTClaimsSet.Builder()
+                .issuer(ISSUER)
+                .subject(ACTOR_SUBJECT_ID)
+                .audience(CLIENT_ID)
+                .claim("azp", ACTOR_CLIENT_ID)
+                .build();
+        return signJWT(keyPair, claims);
+    }
+
+    private RequestParameter[] buildDelegationRequestParams(SignedJWT subjectToken, SignedJWT actorToken) {
+
+        return new RequestParameter[]{
+                new RequestParameter(Constants.TokenExchangeConstants.SUBJECT_TOKEN_TYPE,
+                        Constants.TokenExchangeConstants.ACCESS_TOKEN_TYPE),
+                new RequestParameter(Constants.TokenExchangeConstants.SUBJECT_TOKEN, subjectToken.serialize()),
+                new RequestParameter("grant_type", Constants.TokenExchangeConstants.TOKEN_EXCHANGE_GRANT_TYPE),
+                new RequestParameter(Constants.TokenExchangeConstants.REQUESTED_TOKEN_TYPE,
+                        Constants.TokenExchangeConstants.ACCESS_TOKEN_TYPE),
+                new RequestParameter(Constants.TokenExchangeConstants.ACTOR_TOKEN, actorToken.serialize()),
+                new RequestParameter(Constants.TokenExchangeConstants.ACTOR_TOKEN_TYPE,
+                        Constants.TokenExchangeConstants.ACCESS_TOKEN_TYPE),
+        };
+    }
+
+    private RequestParameter[] buildSelfDelegationRequestParams(SignedJWT subjectToken) {
+
+        return new RequestParameter[]{
+                new RequestParameter(Constants.TokenExchangeConstants.SUBJECT_TOKEN_TYPE,
+                        Constants.TokenExchangeConstants.JWT_TOKEN_TYPE),
+                new RequestParameter(Constants.TokenExchangeConstants.SUBJECT_TOKEN, subjectToken.serialize()),
+                new RequestParameter("grant_type", Constants.TokenExchangeConstants.TOKEN_EXCHANGE_GRANT_TYPE),
+                new RequestParameter(Constants.TokenExchangeConstants.REQUESTED_TOKEN_TYPE,
+                        Constants.TokenExchangeConstants.ACCESS_TOKEN_TYPE),
+        };
+    }
+
+    private void prepareTokenUtilsForDelegation(SignedJWT subjectToken, SignedJWT actorToken) throws ParseException {
+
+        tokenExchangeUtils.when(() -> TokenExchangeUtils.getSignedJWT(subjectToken.serialize()))
+                .thenReturn(subjectToken);
+        tokenExchangeUtils.when(() -> TokenExchangeUtils.getClaimSet(subjectToken))
+                .thenReturn(subjectToken.getJWTClaimsSet());
+        tokenExchangeUtils.when(() -> TokenExchangeUtils.validateSignature(subjectToken, idp, "carbon.super"))
+                .thenReturn(true);
+        tokenExchangeUtils.when(() -> TokenExchangeUtils.getSignedJWT(actorToken.serialize()))
+                .thenReturn(actorToken);
+        tokenExchangeUtils.when(() -> TokenExchangeUtils.getClaimSet(actorToken))
+                .thenReturn(actorToken.getJWTClaimsSet());
+        tokenExchangeUtils.when(() -> TokenExchangeUtils.validateSignature(actorToken, idp, "carbon.super"))
+                .thenReturn(true);
+        oAuth2Util.when(() -> OAuth2Util.isJWT(actorToken.serialize())).thenReturn(true);
+        AbstractUserStoreManager mockUserStoreManager = Mockito.mock(AbstractUserStoreManager.class);
+        try {
+            Mockito.doReturn("actorUser").when(mockUserStoreManager).getUserNameFromUserID(ACTOR_SUBJECT_ID);
+        } catch (org.wso2.carbon.user.core.UserStoreException e) {
+            throw new RuntimeException(e);
+        }
+        tokenExchangeUtils.when(() -> TokenExchangeUtils.getUserStoreManager(Mockito.any()))
+                .thenReturn(mockUserStoreManager);
+        tokenExchangeUtils.when(() -> TokenExchangeUtils.setAuthorizedUserForImpersonation(
+                        Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.any(), Mockito.anyString()))
+                .thenAnswer(invocation -> null);
+    }
+
+    private void prepareTokenUtilsForSelfDelegation(SignedJWT subjectToken) throws ParseException {
+
+        tokenExchangeUtils.when(() -> TokenExchangeUtils.getSignedJWT(subjectToken.serialize()))
+                .thenReturn(subjectToken);
+        tokenExchangeUtils.when(() -> TokenExchangeUtils.getClaimSet(subjectToken))
+                .thenReturn(subjectToken.getJWTClaimsSet());
+        tokenExchangeUtils.when(() -> TokenExchangeUtils.validateSignature(subjectToken, idp, "carbon.super"))
+                .thenReturn(true);
+        tokenExchangeUtils.when(() -> TokenExchangeUtils.setAuthorizedUserForImpersonation(
+                        Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.any(), Mockito.anyString()))
+                .thenAnswer(invocation -> null);
+    }
 
     @AfterTest
     public void close() {

--- a/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/test/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandlerTest.java
+++ b/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/test/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandlerTest.java
@@ -298,9 +298,8 @@ public class TokenExchangeGrantHandlerTest {
 
         return new Object[][]{
                 {true, false, ISSUER, CLIENT_ID, IMPERSONATOR_ID, false, ISSUER, IMPERSONATOR_ID},
-                {true, true, ISSUER, CLIENT_ID, IMPERSONATOR_ID, false, ISSUER, IMPERSONATOR_ID},
                 {false, false, "NegativeIssuer", CLIENT_ID, IMPERSONATOR_ID, false, ISSUER, IMPERSONATOR_ID},
-                {true, true, ISSUER, "NegativeClient", IMPERSONATOR_ID, false, ISSUER, IMPERSONATOR_ID},
+                {false, false, ISSUER, "NegativeClient", IMPERSONATOR_ID, false, ISSUER, IMPERSONATOR_ID},
                 {false, false, ISSUER, CLIENT_ID, IMPERSONATOR_ID, true, ISSUER, IMPERSONATOR_ID},
                 {false, false, ISSUER, CLIENT_ID, IMPERSONATOR_ID, false, "NegativeIssuer", IMPERSONATOR_ID},
                 {false, false, ISSUER, CLIENT_ID, IMPERSONATOR_ID, false, ISSUER, "NegativeImpersonator"}
@@ -362,6 +361,11 @@ public class TokenExchangeGrantHandlerTest {
                 .thenReturn(actorToken.getJWTClaimsSet());
         tokenExchangeUtils.when(() -> TokenExchangeUtils.validateSignature(actorToken, idp, "carbon.super"))
                 .thenReturn(true);
+        tokenExchangeUtils.when(() -> TokenExchangeUtils.handleClientException(anyString(), anyString()))
+                .thenAnswer(invocation -> {
+                    throw new IdentityOAuth2ClientException(invocation.getArgument(0, String.class),
+                            invocation.getArgument(1, String.class));
+                });
     }
 
 

--- a/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/test/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandlerTest.java
+++ b/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/test/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandlerTest.java
@@ -32,6 +32,7 @@ import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
 import org.wso2.carbon.identity.application.common.model.IdentityProvider;
 import org.wso2.carbon.identity.application.common.model.IdentityProviderProperty;
 import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
@@ -469,6 +470,25 @@ public class TokenExchangeGrantHandlerTest {
         Assert.assertNotNull(ctx.getProperty(EXISTING_ACT_CLAIM), "Existing act claim must be preserved on context");
     }
 
+    @Test(expectedExceptions = IdentityOAuth2Exception.class)
+    public void testValidateDelegationActorTokenMissingClientId() throws Exception {
+
+        SignedJWT subjectToken = buildDelegationSubjectToken();
+        SignedJWT actorToken = buildActorTokenForDelegationWithoutClientId();
+
+        OAuth2AccessTokenReqDTO reqDTO = new OAuth2AccessTokenReqDTO();
+        reqDTO.setClientId(CLIENT_ID);
+        reqDTO.setGrantType(Constants.TokenExchangeConstants.TOKEN_EXCHANGE_GRANT_TYPE);
+        reqDTO.setTenantDomain("carbon.super");
+        reqDTO.setScope(new String[]{"default"});
+        reqDTO.setRequestParameters(buildDelegationRequestParams(subjectToken, actorToken));
+        OAuthTokenReqMessageContext ctx = new OAuthTokenReqMessageContext(reqDTO);
+
+        prepareTokenUtilsForDelegation(subjectToken, actorToken);
+        // Actor token without azp or client_id cannot be resolved to an application.
+        tokenExchangeGrantHandler.validateGrant(ctx);
+    }
+
     @DataProvider(name = "delegationNegativeTestData")
     public Object[][] delegationNegativeTestData() {
 
@@ -558,6 +578,22 @@ public class TokenExchangeGrantHandlerTest {
         return signJWT(keyPair, claims);
     }
 
+    private SignedJWT buildActorTokenForDelegationWithoutClientId() throws NoSuchAlgorithmException, JOSEException {
+
+        KeyPairGenerator keyGenerator = KeyPairGenerator.getInstance("RSA");
+        KeyPair keyPair = keyGenerator.generateKeyPair();
+        Instant now = Instant.now();
+        JWTClaimsSet claims = new JWTClaimsSet.Builder()
+                .issuer(ISSUER)
+                .subject(ACTOR_SUBJECT_ID)
+                .audience(CLIENT_ID)
+                .issueTime(Date.from(now))
+                .expirationTime(Date.from(Instant.ofEpochSecond(now.getEpochSecond() + 36000)))
+                .notBeforeTime(Date.from(now))
+                .build();
+        return signJWT(keyPair, claims);
+    }
+
     private SignedJWT buildActorTokenForDelegationWithoutExpiry() throws NoSuchAlgorithmException, JOSEException {
 
         KeyPairGenerator keyGenerator = KeyPairGenerator.getInstance("RSA");
@@ -622,6 +658,11 @@ public class TokenExchangeGrantHandlerTest {
         }
         tokenExchangeUtils.when(() -> TokenExchangeUtils.getUserStoreManager(Mockito.any()))
                 .thenReturn(mockUserStoreManager);
+        AuthenticatedUser actorUser = new AuthenticatedUser();
+        actorUser.setUserName("actorUser");
+        oAuth2Util.when(() -> OAuth2Util.getAuthenticatedUserFromSubjectIdentifier(
+                        Mockito.anyString(), Mockito.nullable(String.class), Mockito.anyString()))
+                .thenReturn(actorUser);
         tokenExchangeUtils.when(() -> TokenExchangeUtils.setAuthorizedUserForImpersonation(
                         Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.any(), Mockito.anyString()))
                 .thenAnswer(invocation -> null);

--- a/pom.xml
+++ b/pom.xml
@@ -271,7 +271,7 @@
         <apache.felix.scr.ds.annotations.version>1.2.4</apache.felix.scr.ds.annotations.version>
         <carbon.p2.plugin.version>1.5.3</carbon.p2.plugin.version>
         <carbon.identity.oauth.package.import.version.range>[6.0.0, 8.0.0)</carbon.identity.oauth.package.import.version.range>
-        <carbon.identity.oauth.version>7.4.84</carbon.identity.oauth.version>
+        <carbon.identity.oauth.version>7.5.70</carbon.identity.oauth.version>
         <carbon.identity.framework.version>7.8.675</carbon.identity.framework.version>
         <commons-lang.wso2.osgi.version.range>[2.6.0,3.0.0)</commons-lang.wso2.osgi.version.range>
         <commons-logging.osgi.version.range>[1.2,2.0)</commons-logging.osgi.version.range>


### PR DESCRIPTION
## Purpose                                                                                                                                                                         
                                                                                                                                                                                     
  Add RFC 8693 **delegation** support to the token exchange grant, alongside the existing impersonation flow. In delegation the acting party's identity is preserved in a nested `act` claim on the issued token, chained across successive delegations.                                                      
                                                                                                                                                                                                                                                                                                                                     
  - **Related to:** wso2/product-is#26673                                                                                                                                            
  - **Merge after:** wso2-extensions/identity-inbound-auth-oauth#3276                                                                                                                
                                                                                                                                                                                     
  ## Description                                                                                                                                                                     
                                                                                                                                                                                     
  ### Token exchange intent detection                                                                                                                                                
                                                                                                                                                                                     
  `validateGrant` classifies the request as one of three flows:                                                                                                                      
                                                                                                                                                                                     
  - **Impersonation** — `subject_token`, `subject_token_type`, `actor_token` and `actor_token_type` are all present, and the subject token carries a `may_act` claim.            
  - **Delegation** — the subject token has no `may_act`, and either the subject token already carries an `act` claim (a previous delegation), or a new actor token is presented.                                                                                                                                                                         
  - **Generic JWT token exchange** — everything else (unchanged).                                                                                                                    
                                                                                                                                                                                     
  ### Delegation validation                                                                                                                                                          
                                                                                                                                                                                     
  - The subject token is validated through the existing `handleJWTSubjectToken` path (signature, validity, audience, issuer, custom claims).                                                                                                                                                                   
  - `validateActorTokenForDelegation` (only when a new actor token is presented):                                                                                                    
    - validates its signature, validity, issuer and mandatory claims;                                                                                                                
    - verifies the actor subject is a registered local user and the user acount is not disabled or locked (`validateActorSubject`) so delegation-chain integrity can be guaranteed.                                                
                                                                                                                                                                                     
  ### Act chain handling                                                                                                                                                             
                                                                                                                                                                                     
  - Any existing `act` claim on the subject token is extracted and validated (`extractActClaim` must be a JSON object with a non-blank `sub`) and preserved on the context as `EXISTING_ACT_CLAIM`, so the token issuer can nest it as the base of the chain rather than recreating it.
 - A new actor adds the next level of the chain only when it differs from the current top of the chain; if the new actor equals the current top, the existing `act` claim is carried forward unchanged (no duplicate level).                                                                                                                                    
  - When re-exchanging a token that already carries an `act` claim without presenting a new actor token, the existing chain is carried forward unchanged, so the re-exchanging application cannot alter it.                                                                                                                                                       
                                                                                                                                                                                     
  ### Context state set for the issuer                                                                                                                                               
                                                                                                                                                                                                                                                                                                  
The `isDelegationRequest()` flag; `EXISTING_ACT_CLAIM` (when the subject token already carries an `act` chain); `ACTOR_SUBJECT` (only when a new actor token is presented and it differs from the current top of the chain).                                                                                                                       
                                                                                                                                                                                     
  ## Sample (sanitized) delegation request                                                                                                                                           
                                                                                                                                                                                     
  ```                                                                                                                                                                                
  POST https://localhost:9443/oauth2/token                                                                                                                                           
                                                                                                                                                                                     
  grant_type: urn:ietf:params:oauth:grant-type:token-exchange                                                                                                                        
  subject_token: <JWT_ACCESS_TOKEN>                                                                                             
  subject_token_type: urn:ietf:params:oauth:token-type:access_token                                                                                                                  
  scope: booking:read                                                                                                                                                                
  actor_token: <JWT_ACCESS_TOKEN>                                                                                                                                                    
  actor_token_type: urn:ietf:params:oauth:token-type:access_token                                                                                                                    
  ```                                                                                                                                                                                
                                                                                                                                                                                     
  ## Expected (sanitized) issued-token claims  
 ```json                                                                                                                                                                            
  {                                                                                                                                                                                  
    "sub": "<SUBJECT_SUB>",                                                                                                                                                          
    "iss": "https://localhost:9443/oauth2/token",                                                                                                                                    
    "client_id": "<CLIENT_ID>",                                                                                                                                                      
    "aud": ["<AUD_1>", "<AUD_2>"],                                                                                                                                                   
    "act": {                                                                                                                                                                         
      "sub": "<ACTOR_SUB>",                                                                                                                                                          
      "act": {                                                                                                                                                                       
        "sub": "<PREVIOUS_ACTOR_SUB>"                                                                                                                                                
      }                                                                                                                                                                              
    },                                                                                                                                                                               
    "scope": "booking:read",                                                                                                                                                         
    "nbf": 1770094002,                                                                                                                                                               
    "exp": 1770097602,                                                                                                                                                               
    "iat": 1770094002                                                                                                                                                                
  }                                                                                                                                                                                  
  ```                                                                                                                                                                                                                                                                                                                                        
                                                                                                                                                                                     
  ## Behavioral compatibility                                                                                                                                                        
                                                                                                                                                                                     
  - Valid impersonation and generic JWT token exchange are unchanged.                                                                                                                
  - Impersonation is now gated on the subject token actually carrying `may_act`. A subject + actor request without `may_act` previously failed (the impersonation path required  an impersonator from `may_act`); it is now handled as a delegation request.                                                  
                                                                                           
  ## Testing                                                                                                                                                                         
                                                                                                                                                                                     
  Added unit tests in `TokenExchangeGrantHandlerTest` covering:                                                                                                                      
                                                                                                                                                                                                                                                                                          
  - delegation with a new actor token (`isDelegationRequest()` true, `ACTOR_SUBJECT` set to the actor);                                                                              
  - delegation re-exchange of a token already carrying an `act` claim with no new actor (`ACTOR_SUBJECT` null, `EXISTING_ACT_CLAIM` preserved);                                      
  - a new actor equal to the current top of the chain (existing `act` carried forward unchanged);
- actor-subject resolution as a registered local user, and negative cases (invalid / expired / missing claims). 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added claim-aware routing for OAuth token exchange, including improved impersonation and delegation handling with delegation-chain processing.
- **Bug Fixes**
  - Hardened delegation validation: enforces actor token constraints, validates JWT integrity/issuer, rejects blank actor subjects, and updates actor-subject context safely.  
  - Ensures unsupported subject token types fail with `invalid_request`.
- **Tests**
  - Expanded unit test coverage for delegation, delegation re-exchange, existing `act` claim preservation, and additional negative scenarios.
- **Documentation**
  - Updated a minor Javadoc wording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->