### PR TITLE
Skip issuer-in-audience validation for locally issued subject tokens 

### DIFF
--- a/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandler.java
+++ b/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandler.java
@@ -684,7 +684,6 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
         SignedJWT signedJWT;
         IdentityProvider identityProvider;
         JWTClaimsSet claimsSet;
-        boolean audienceFound;
 
         signedJWT = getSignedJWT(requestParams.get(Constants.TokenExchangeConstants.SUBJECT_TOKEN));
         if (signedJWT != null) {
@@ -748,10 +747,14 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
             checkJWTValidity(claimsSet);
 
             RequestParameter[] params = tokReqMsgCtx.getOauth2AccessTokenReqDTO().getRequestParameters();
-            audienceFound = validateAudience(audiences, identityProvider, requestedAudience, params, tenantDomain);
-            if (!audienceFound) {
-                TokenExchangeUtils.handleClientException(Constants.TokenExchangeConstants.INVALID_TARGET,
-                        "Invalid audience values provided");
+            // Skip the issuer-in-audience check for locally issued tokens; the local issuer is already trusted.
+            if (!isLocalIdentityProvider) {
+                boolean audienceFound = validateAudience(audiences, identityProvider, requestedAudience, params,
+                        tenantDomain);
+                if (!audienceFound) {
+                    TokenExchangeUtils.handleClientException(Constants.TokenExchangeConstants.INVALID_TARGET,
+                            "Invalid audience values provided");
+                }
             }
 
             try {


### PR DESCRIPTION
 ## Description                                                                                                                                                                                                                         
                                                                                                                                                                                                                                         
 Fixes subject token issuer/audience validation so that locally-issued tokens no longer need the issuer explicitly listed in the token's `aud` claim.                                                                            
                                                                                                                                                                                                                                         
  - The subject token's issuer (`iss`) is resolved and matched to a trusted identity provider (unchanged).                                                                                                                               
  - **Audience validation** now depends on the resolved issuer:                                                                                                                                                                          
    - **External IdP** — behaviour is unchanged: the issuer must be present in the token's `aud` list, otherwise the request is rejected with `Invalid audience values provided`.                                     
    - **Local IdP** — the issuer-in-audience check is skipped, since a locally-issued token is already trusted. This lets local tokens be validated without requiring the issuer to be included in `aud`.                            
                                                                                                                                                                                                                                                                                                                                                                                                   
  **Related to:** https://github.com/wso2/product-is/issues/26676                                                                                                                                                                                                 
                                                                                                                                                                                                                                         
  ## Changed files                                                                                                                                                                                                                       
                                                                                                                                                                                                                                         
  - `TokenExchangeGrantHandler.java` — skip the issuer-in-audience validation for locally issued tokens (`isLocalIdentityProvider`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated token exchange validation to allow locally issued tokens without requiring the issuer to appear in the audience.
  * Continued audience validation for tokens issued by external identity providers, with invalid targets rejected appropriately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->