### PR TITLE
Add audience parameter support in token exchange grant for delegation flow

### DIFF
--- a/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandler.java
+++ b/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandler.java
@@ -91,6 +91,7 @@ import static org.wso2.carbon.identity.oauth2.grant.token.exchange.utils.TokenEx
 import static org.wso2.carbon.identity.oauth2.grant.token.exchange.utils.TokenExchangeUtils.getIDP;
 import static org.wso2.carbon.identity.oauth2.grant.token.exchange.utils.TokenExchangeUtils.getIDPAlias;
 import static org.wso2.carbon.identity.oauth2.grant.token.exchange.utils.TokenExchangeUtils.getSignedJWT;
+import static org.wso2.carbon.identity.oauth2.grant.token.exchange.utils.TokenExchangeUtils.handleClientException;
 import static org.wso2.carbon.identity.oauth2.grant.token.exchange.utils.TokenExchangeUtils.handleCustomClaims;
 import static org.wso2.carbon.identity.oauth2.grant.token.exchange.utils.TokenExchangeUtils.handleException;
 import static org.wso2.carbon.identity.oauth2.grant.token.exchange.utils.TokenExchangeUtils.parseTokenExchangeConfiguration;
@@ -799,10 +800,11 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
 
         String[] audienceValues = requestedAudience.trim().split("\\s+");
         if (audienceValues.length > 1) {
-            handleException(TokenExchangeConstants.INVALID_TARGET, "Multiple audience values provided in the request");
+            handleClientException(TokenExchangeConstants.INVALID_TARGET,
+                    "Multiple audience values provided in the request");
         }
         if (!allowedAudiences.contains(audienceValues[0])) {
-            handleException(TokenExchangeConstants.INVALID_TARGET,
+            handleClientException(TokenExchangeConstants.INVALID_TARGET,
                     "Invalid audience value provided : " + audienceValues[0]);
         }
         if (log.isDebugEnabled()) {

--- a/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandler.java
+++ b/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandler.java
@@ -793,7 +793,7 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
             return allowedAudiences;
         }
         String requestedAudience = getRequestedAudience(tokReqMsgCtx);
-        if (StringUtils.isBlank(requestedAudience)) {
+        if (requestedAudience == null) {
             return allowedAudiences;
         }
 
@@ -826,10 +826,7 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
         for (RequestParameter param : params) {
             if (TokenExchangeConstants.AUDIENCE.equals(param.getKey())) {
                 String[] values = param.getValue();
-                if (values == null || values.length == 0) {
-                    return null;
-                }
-                return String.join(" ", values);
+                return (values != null && values.length > 0) ? values[0] : null;
             }
         }
         return null;

--- a/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandler.java
+++ b/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandler.java
@@ -38,6 +38,7 @@ import org.wso2.carbon.identity.event.IdentityEventException;
 import org.wso2.carbon.identity.handler.event.account.lock.exception.AccountLockException;
 import org.wso2.carbon.identity.oauth.common.OAuth2ErrorCodes;
 import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
+import org.wso2.carbon.identity.oauth.dao.OAuthAppDO;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.config.exceptions.OAuth2OIDCConfigOrgUsageScopeMgtServerException;
 import org.wso2.carbon.identity.oauth2.config.utils.OAuth2OIDCConfigOrgUsageScopeUtils;
@@ -63,6 +64,7 @@ import org.wso2.carbon.utils.DiagnosticLog;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -767,6 +769,70 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
             handleException(OAuth2ErrorCodes.ACCESS_DENIED,
                     "Actor account is inactive.");
         }
+    }
+
+    /**
+     * Constrains the token audience to the requested {@code audience} parameter. Ignored for impersonation
+     * requests. Throws if more than one audience is requested, or the requested audience is not a registered
+     * audience of the application.
+     *
+     * @param tokReqMsgCtx Token request message context.
+     * @param consumerKey  Consumer key of the application.
+     * @param oAuthAppBean Application information.
+     * @return the resolved audience list.
+     * @throws IdentityOAuth2Exception if the requested audience is invalid, or an error occurred while
+     *                                 resolving the audiences.
+     */
+    @Override
+    protected List<String> resolveAudiences(OAuthTokenReqMessageContext tokReqMsgCtx, String consumerKey,
+                                            OAuthAppDO oAuthAppBean) throws IdentityOAuth2Exception {
+
+        List<String> allowedAudiences = OAuth2Util.getOIDCAudience(consumerKey, oAuthAppBean);
+
+        if (tokReqMsgCtx.isImpersonationRequest()) {
+            return allowedAudiences;
+        }
+        String requestedAudience = getRequestedAudience(tokReqMsgCtx);
+        if (StringUtils.isBlank(requestedAudience)) {
+            return allowedAudiences;
+        }
+
+        String[] audienceValues = requestedAudience.trim().split("\\s+");
+        if (audienceValues.length > 1) {
+            handleException(TokenExchangeConstants.INVALID_TARGET, "Multiple audience values provided in the request");
+        }
+        if (!allowedAudiences.contains(audienceValues[0])) {
+            handleException(TokenExchangeConstants.INVALID_TARGET,
+                    "Invalid audience value provided : " + audienceValues[0]);
+        }
+        if (log.isDebugEnabled()) {
+            log.debug("Limiting token audience to the requested audience: " + audienceValues[0]);
+        }
+        return Collections.singletonList(audienceValues[0]);
+    }
+
+    /**
+     * Reads the {@code audience} parameter from the token exchange request, if present.
+     *
+     * @param tokReqMsgCtx Token request message context.
+     * @return the raw requested audience value, or {@code null} if not present.
+     */
+    private String getRequestedAudience(OAuthTokenReqMessageContext tokReqMsgCtx) {
+
+        RequestParameter[] params = tokReqMsgCtx.getOauth2AccessTokenReqDTO().getRequestParameters();
+        if (params == null) {
+            return null;
+        }
+        for (RequestParameter param : params) {
+            if (TokenExchangeConstants.AUDIENCE.equals(param.getKey())) {
+                String[] values = param.getValue();
+                if (values == null || values.length == 0) {
+                    return null;
+                }
+                return String.join(" ", values);
+            }
+        }
+        return null;
     }
 
     /**

--- a/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/test/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandlerTest.java
+++ b/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/test/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandlerTest.java
@@ -206,20 +206,27 @@ public class TokenExchangeGrantHandlerTest {
     }
 
     @Test(dataProvider = "invalidRequestedAudienceDataProvider",
-            expectedExceptions = IdentityOAuth2Exception.class)
+            expectedExceptions = IdentityOAuth2ClientException.class)
     public void testResolveAudiencesThrowsForInvalidRequestedAudience(String requestedAudience) throws Exception {
 
         oAuth2Util.when(() -> OAuth2Util.getOIDCAudience(anyString(), any()))
                 .thenReturn(Arrays.asList("https://api.example.com", CLIENT_ID));
 
-        OAuth2AccessTokenReqDTO reqDTO = new OAuth2AccessTokenReqDTO();
-        reqDTO.setClientId(CLIENT_ID);
-        reqDTO.setGrantType(Constants.TokenExchangeConstants.TOKEN_EXCHANGE_GRANT_TYPE);
-        reqDTO.setRequestParameters(new RequestParameter[]{
-                new RequestParameter(Constants.TokenExchangeConstants.AUDIENCE, requestedAudience)});
-        OAuthTokenReqMessageContext ctx = new OAuthTokenReqMessageContext(reqDTO);
+        tokenExchangeUtils.when(() -> TokenExchangeUtils.handleClientException(anyString(), anyString()))
+                .thenThrow(new IdentityOAuth2ClientException("invalid_target", "Invalid audience value provided"));
+        try {
+            OAuth2AccessTokenReqDTO reqDTO = new OAuth2AccessTokenReqDTO();
+            reqDTO.setClientId(CLIENT_ID);
+            reqDTO.setGrantType(Constants.TokenExchangeConstants.TOKEN_EXCHANGE_GRANT_TYPE);
+            reqDTO.setRequestParameters(new RequestParameter[]{
+                    new RequestParameter(Constants.TokenExchangeConstants.AUDIENCE, requestedAudience)});
+            OAuthTokenReqMessageContext ctx = new OAuthTokenReqMessageContext(reqDTO);
 
-        tokenExchangeGrantHandler.resolveAudiences(ctx, CLIENT_ID, mock(OAuthAppDO.class));
+            tokenExchangeGrantHandler.resolveAudiences(ctx, CLIENT_ID, mock(OAuthAppDO.class));
+        } finally {
+            tokenExchangeUtils.when(() -> TokenExchangeUtils.handleClientException(anyString(), anyString()))
+                    .thenAnswer(invocation -> null);
+        }
     }
 
     @Test

--- a/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/test/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandlerTest.java
+++ b/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/test/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandlerTest.java
@@ -200,6 +200,8 @@ public class TokenExchangeGrantHandlerTest {
         return new Object[][]{
                 {"https://api.example.com https://api2.example.com"},
                 {"https://not-allowed.example.com"},
+                {""},
+                {"   "},
         };
     }
 

--- a/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/test/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandlerTest.java
+++ b/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/test/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandlerTest.java
@@ -36,6 +36,7 @@ import org.wso2.carbon.identity.application.authentication.framework.model.Authe
 import org.wso2.carbon.identity.application.common.model.IdentityProvider;
 import org.wso2.carbon.identity.application.common.model.IdentityProviderProperty;
 import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
+import org.wso2.carbon.identity.oauth.dao.OAuthAppDO;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2ClientException;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2AccessTokenReqDTO;
@@ -52,11 +53,14 @@ import java.security.NoSuchAlgorithmException;
 import java.security.interfaces.RSAPrivateKey;
 import java.text.ParseException;
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -153,6 +157,67 @@ public class TokenExchangeGrantHandlerTest {
 
         boolean isValid = tokenExchangeGrantHandler.validateGrant(tokReqMsgCtx);
         Assert.assertTrue(isValid);
+    }
+
+    @DataProvider(name = "resolveAudiencesDataProvider")
+    public Object[][] resolveAudiencesDataProvider() {
+
+        List<String> allowed = Arrays.asList("https://api.example.com", CLIENT_ID);
+        // requestedAudience, allowedAudiences, isImpersonation, expectedAudiences
+        return new Object[][]{
+                {"https://api.example.com", allowed, false, Collections.singletonList("https://api.example.com")},
+                {null, allowed, false, allowed},
+                {"https://not-allowed.example.com", allowed, true, allowed},
+        };
+    }
+
+    @Test(dataProvider = "resolveAudiencesDataProvider")
+    public void testResolveAudiences(String requestedAudience, List<String> allowedAudiences,
+                                     boolean isImpersonation, List<String> expectedAudiences) throws Exception {
+
+        oAuth2Util.when(() -> OAuth2Util.getOIDCAudience(anyString(), any())).thenReturn(allowedAudiences);
+
+        OAuth2AccessTokenReqDTO reqDTO = new OAuth2AccessTokenReqDTO();
+        reqDTO.setClientId(CLIENT_ID);
+        reqDTO.setGrantType(Constants.TokenExchangeConstants.TOKEN_EXCHANGE_GRANT_TYPE);
+        if (requestedAudience != null) {
+            reqDTO.setRequestParameters(new RequestParameter[]{
+                    new RequestParameter(Constants.TokenExchangeConstants.AUDIENCE, requestedAudience)});
+        } else {
+            reqDTO.setRequestParameters(new RequestParameter[0]);
+        }
+        OAuthTokenReqMessageContext ctx = new OAuthTokenReqMessageContext(reqDTO);
+        ctx.setImpersonationRequest(isImpersonation);
+
+        List<String> resolvedAudiences =
+                tokenExchangeGrantHandler.resolveAudiences(ctx, CLIENT_ID, mock(OAuthAppDO.class));
+        Assert.assertEquals(resolvedAudiences, expectedAudiences);
+    }
+
+    @DataProvider(name = "invalidRequestedAudienceDataProvider")
+    public Object[][] invalidRequestedAudienceDataProvider() {
+
+        return new Object[][]{
+                {"https://api.example.com https://api2.example.com"},
+                {"https://not-allowed.example.com"},
+        };
+    }
+
+    @Test(dataProvider = "invalidRequestedAudienceDataProvider",
+            expectedExceptions = IdentityOAuth2Exception.class)
+    public void testResolveAudiencesThrowsForInvalidRequestedAudience(String requestedAudience) throws Exception {
+
+        oAuth2Util.when(() -> OAuth2Util.getOIDCAudience(anyString(), any()))
+                .thenReturn(Arrays.asList("https://api.example.com", CLIENT_ID));
+
+        OAuth2AccessTokenReqDTO reqDTO = new OAuth2AccessTokenReqDTO();
+        reqDTO.setClientId(CLIENT_ID);
+        reqDTO.setGrantType(Constants.TokenExchangeConstants.TOKEN_EXCHANGE_GRANT_TYPE);
+        reqDTO.setRequestParameters(new RequestParameter[]{
+                new RequestParameter(Constants.TokenExchangeConstants.AUDIENCE, requestedAudience)});
+        OAuthTokenReqMessageContext ctx = new OAuthTokenReqMessageContext(reqDTO);
+
+        tokenExchangeGrantHandler.resolveAudiences(ctx, CLIENT_ID, mock(OAuthAppDO.class));
     }
 
     @Test


### PR DESCRIPTION
 ### Summary                                                                                                                                                                                                                            
                                                                                                                                                                                                                                         
  Adds support for the `audience` request parameter in the token exchange grant, letting a client narrow the issued token's audience to a single registered value. Implemented by overriding the `resolveAudiences(...)` extension point 
  introduced in the issuer framework, so the constrained audience is applied during token creation.                                                                                                                                      
                                                                                                                                                                                                                                                                                                                                                                                                
  Merge after: 
wso2-extensions/identity-inbound-auth-oauth#3278
https://github.com/wso2-extensions/identity-oauth2-grant-token-exchange/pull/74                                                                                                                                        
  Related to: wso2/product-is#26675                                                                                                                                                                                                      
                                                                                                                                                                                                                                         
  ### Changes                                                                                                                                                                                                                            
                                                                                                                                                                                                                                         
  #### `TokenExchangeGrantHandler.java`                                                                                                                                                                                                  
                                                                                                                                                                                                                                         
  - Overrides `resolveAudiences(tokReqMsgCtx, consumerKey, oAuthAppBean)` to constrain the token audience based on the request's `audience` parameter:                                                                                   
    - **Impersonation requests** — the parameter is ignored; the application's configured OIDC audiences are returned unchanged.                                                                                                         
    - **No `audience` parameter** — the default configured audiences are returned.                                                                                                                                               
    - **Multiple space-separated values** — rejected with `INVALID_TARGET` ("Multiple audience values provided in the request").                                                                                                         
    - **A single value that is blank or not among the application's registered audiences** — rejected with `INVALID_TARGET` ("Invalid audience value provided : …").                                                                                      
    - **A single, registered value** — the token audience is narrowed to just that value.                                                                                                                                                
  - Adds a private `getRequestedAudience(...)` helper that reads the `audience` request parameter (returns `null` when absent).                                                                                                          
                                                                                                                                                                                                                                         
  #### `TokenExchangeGrantHandlerTest.java`                                                                                                                                                                                              
                                                                                                                                                                                                                                         
  - Adds tests for `resolveAudiences(...)`: single allowed audience narrows the list, blank/absent falls back to defaults, impersonation ignores the parameter, and invalid inputs (multiple values, unregistered value) throw `IdentityOAuth2Exception`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Token exchange requests can now specify a single intended audience.
  - Requested audiences are validated against the application’s allowed audiences.
  - Impersonation requests continue to use the application’s configured audiences.

- **Bug Fixes**
  - Invalid, multiple, or unauthorized audience values are rejected with an appropriate error.
  - Audience values are consistently handled when requests include extra whitespace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->