### PR TITLE
Limit issued scopes to subject token scopes in token exchange grant

### DIFF
--- a/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/Constants.java
+++ b/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/Constants.java
@@ -46,6 +46,8 @@ public class Constants {
     public static final String INCLUDE_PRIMARY_WHEN_SECONDARY_PRESENT_IN_TOKEN_EXCHANGE_IMPLICIT_ASSOCIATION =
             "TokenExchange.ImplicitAssociation.IncludePrimaryWhenSecondaryPresent";
 
+    public static final String LIMIT_SCOPES_TO_SUBJECT_TOKEN = "TokenExchange.LimitScopesToSubjectToken";
+
     /**
      * Constants for Token Exchange grant type.
      */

--- a/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandler.java
+++ b/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/TokenExchangeGrantHandler.java
@@ -399,6 +399,32 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
         return commonScopes.toArray(new String[0]);
     }
 
+    /**
+     * Resolves the scopes for the issued token and sets them on the request context. For local IdP subject
+     * tokens, limits the scopes to the intersection of the requested and subject token scopes on delegation requests
+     * or when the "LimitScopesToSubjectToken" configuration is enabled.
+     *
+     * @param tokReqMsgCtx            Token request message context.
+     * @param claimsSet               Subject token claims.
+     * @param isLocalIdentityProvider Whether the subject token was issued by the local (resident) IdP.
+     */
+    private void handleRequestedScopes(OAuthTokenReqMessageContext tokReqMsgCtx, JWTClaimsSet claimsSet,
+                                       boolean isLocalIdentityProvider) {
+
+        RequestParameter[] params = tokReqMsgCtx.getOauth2AccessTokenReqDTO().getRequestParameters();
+        Map<String, String> requestParams = Arrays.stream(params).collect(Collectors.toMap(RequestParameter::getKey,
+                requestParam -> requestParam.getValue()[0]));
+
+        String[] requestedScopes = tokReqMsgCtx.getOauth2AccessTokenReqDTO().getScope();
+        boolean enableScopeLimiting = hasSubjectAndActorTokenParameters(requestParams)
+                || TokenExchangeUtils.isLimitScopesToSubjectTokenEnabled();
+
+        if (enableScopeLimiting && isLocalIdentityProvider && ArrayUtils.isNotEmpty(requestedScopes)) {
+            tokReqMsgCtx.setScope(getScopes(claimsSet, tokReqMsgCtx));
+        } else {
+            tokReqMsgCtx.setScope(requestedScopes);
+        }
+    }
 
     private String resolveImpersonator(JWTClaimsSet claimsSet) {
 
@@ -1049,7 +1075,7 @@ public class TokenExchangeGrantHandler extends AbstractAuthorizationGrantHandler
             log.debug("Subject(sub) found in JWT: " + subject + " and set as the Authorized User.");
         }
 
-        tokReqMsgCtx.setScope(tokReqMsgCtx.getOauth2AccessTokenReqDTO().getScope());
+        handleRequestedScopes(tokReqMsgCtx, claimsSet, isLocalIdentityProvider);
         enrichCustomClaims(customClaims, identityProvider, params);
         log.debug("Subject JWT Token was validated successfully");
         if (OAuth2Util.isOIDCAuthzRequest(tokReqMsgCtx.getScope())) {

--- a/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/utils/TokenExchangeUtils.java
+++ b/component/org.wso2.carbon.identity.oauth2.grant.token.exchange/src/main/java/org/wso2/carbon/identity/oauth2/grant/token/exchange/utils/TokenExchangeUtils.java
@@ -1331,6 +1331,16 @@ public class TokenExchangeUtils {
     }
 
     /**
+     * Check whether limit scopes to subject token is enabled.
+     *
+     * @return true if scope limiting is enabled, false otherwise.
+     */
+    public static boolean isLimitScopesToSubjectTokenEnabled() {
+
+        return Boolean.parseBoolean(IdentityUtil.getProperty(Constants.LIMIT_SCOPES_TO_SUBJECT_TOKEN));
+    }
+
+    /**
      * Method to get the assert local user behaviour based on the service provider claim configuration.
      * @param claimConfig  Claim configuration of the service provider.
      * @return Assert local user behaviour.


### PR DESCRIPTION
 ## Summary                                                                                                                                                                         
                                                                                                                                                                                     
  Limits the scopes of the issued token to those approved in the subject token, when an actor token is present for delegation or when the new `TokenExchange.LimitScopesToSubjectToken` configuration is enabled. The restriction applies only to locally issued subject tokens; all other flows keep the existing behaviour of honouring the requested scopes.       
                                                                                                                                                                                     
  Merge after: wso2-extensions/identity-oauth2-grant-token-exchange#71                                                                                                               
  Related to: https://github.com/wso2/product-is/issues/28212
 
Merge After: 
https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/3276 
https://github.com/wso2/carbon-identity-framework/pull/8214
https://github.com/wso2-extensions/identity-oauth2-grant-token-exchange/pull/71                                                                                                                                                 
                                                                                                                                                                                     
  ## Changes                                                                                                                                                                         
                                                                                                                                                                                     
  ### `TokenExchangeGrantHandler.java`                                                                                                                                               
  - Adds a private `handleRequestedScopes(tokReqMsgCtx, claimsSet, isLocalIdentityProvider)` that decides the token scopes:                                                          
    - Scope limiting is active when the request is not impersonation, it contains an actor token or`TokenExchange.LimitScopesToSubjectToken` is enabled and the subject token is from the local IdP.
    - The scopes are narrowed to the intersection of the requested scopes and the subject token's approved scopes (via the existing `getScopes(...)`).                              
    - Otherwise the requested scopes are used unchanged preserving the pre-existing behaviour.                                             
  - `handleJWTSubjectToken(...)` now routes scope resolution through `handleRequestedScopes(...)` instead of unconditionally setting the requested scopes.                           
                                                                                                                                                                                     
  ### `TokenExchangeUtils.java`                                                                                                                                                      
  - Adds `isLimitScopesToSubjectTokenEnabled()`, reading the `TokenExchange.LimitScopesToSubjectToken` identity configuration.                                                       
                                                                                                                                                                                     
  ### `Constants.java`                                                                                                                                                               
  - Adds the `LIMIT_SCOPES_TO_SUBJECT_TOKEN` config key (`TokenExchange.LimitScopesToSubjectToken`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable scope limiting for token exchange based on subject-token permissions.
  * Improved delegation and impersonation exchanges, including actor-token validation and preservation of delegation chains.
  * Added validation for account lock and account disable status during token exchange.
  * Requested scopes remain unchanged when limiting is disabled or not applicable.

* **Bug Fixes**
  * Improved handling of invalid or incomplete subject and actor tokens, including missing client identifiers and expiry claims.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->